### PR TITLE
chore: update repo paths and prep v0.0.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "codehud"
-version = "0.2.0"
+version = "0.0.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Code HUD - A tree-sitter powered code context extractor"
-repository = "https://github.com/Last-but-not-least/codeview"
+repository = "https://github.com/Tidemarks-AI/Code-HUD"
 keywords = ["tree-sitter", "code-analysis", "refactoring", "cli"]
 categories = ["command-line-utilities", "development-tools", "parsing"]
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ A code context extractor powered by [Tree-sitter](https://tree-sitter.github.io/
 ### Quick install (Linux / macOS)
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Last-but-not-least/codeview/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh
 ```
 
 This auto-detects your OS and architecture, downloads the latest release binary, and installs to `/usr/local/bin`. Set `INSTALL_DIR` to change the location, or `VERSION` to pin a specific version:
 
 ```sh
-INSTALL_DIR=~/.local/bin VERSION=v0.0.1 curl -fsSL https://raw.githubusercontent.com/Last-but-not-least/codeview/main/install.sh | sh
+INSTALL_DIR=~/.local/bin VERSION=v0.0.1 curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh
 ```
 
 ### Download from GitHub Releases
 
-Prebuilt binaries for every release: [GitHub Releases](https://github.com/Last-but-not-least/codeview/releases)
+Prebuilt binaries for every release: [GitHub Releases](https://github.com/Tidemarks-AI/Code-HUD/releases)
 
 | Target | Archive |
 |--------|---------|

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # Install script for Code HUD
-# Usage: curl -fsSL https://raw.githubusercontent.com/Last-but-not-least/codeview/main/install.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh
 
 set -eu
 
-REPO="Last-but-not-least/codeview"
+REPO="Tidemarks-AI/Code-HUD"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 get_target() {


### PR DESCRIPTION
Updates all references from Last-but-not-least/codeview to Tidemarks-AI/Code-HUD. Sets version to 0.0.1.