### PR TITLE
feat: add outline mode (refs #5, refs #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 -e /target
 .openclaw/
 .cargo/config.toml
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "codeview"
+name = "codehud"
 version = "0.2.0"
 dependencies = [
  "clap",

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,6 +1,7 @@
 pub mod collapse;
 pub mod interface;
 pub mod expand;
+pub mod outline;
 
 use serde::Serialize;
 

--- a/src/extractor/outline.rs
+++ b/src/extractor/outline.rs
@@ -1,0 +1,323 @@
+//! Outline mode: signatures + docstrings + types, no implementation bodies.
+//!
+//! Middle ground between `--list-symbols` (one-liner per symbol) and full expand.
+//! Shows the shape of code with enough detail to understand the API.
+
+use super::{find_attr_start, Item, ItemKind, Visibility};
+use crate::handler::{self, LanguageHandler};
+use crate::languages::{ts_language, Language};
+use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
+use std::collections::BTreeMap;
+
+/// Extract outline view: signatures + docstrings, no bodies.
+pub fn extract_outline(source: &str, tree: &Tree, language: Language, pub_only: bool) -> Vec<Item> {
+    let handler = handler::handler_for(language)
+        .expect("all supported languages have handlers");
+    extract_outline_with_handler(source, tree, language, handler.as_ref(), pub_only)
+}
+
+fn extract_outline_with_handler(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    handler: &dyn LanguageHandler,
+    pub_only: bool,
+) -> Vec<Item> {
+    let ts_lang = ts_language(language);
+    let query = Query::new(&ts_lang, handler.symbol_query())
+        .expect("symbol_query should compile");
+
+    let mut cursor = QueryCursor::new();
+    cursor.set_max_start_depth(Some(2));
+    let source_bytes = source.as_bytes();
+
+    let item_idx = query.capture_index_for_name("item").unwrap();
+    let name_idx = query.capture_index_for_name("name");
+
+    let mut items_map: BTreeMap<usize, Item> = BTreeMap::new();
+    let mut seen_names = std::collections::HashSet::new();
+
+    let root = tree.root_node();
+    let mut matches_iter = cursor.matches(&query, root, source_bytes);
+
+    while let Some(m) = matches_iter.next() {
+        let item_node = match m.captures.iter().find(|c| c.index == item_idx) {
+            Some(c) => c.node,
+            None => continue,
+        };
+
+        // Deduplicate by name node position
+        if let Some(ni) = name_idx {
+            if let Some(nc) = m.captures.iter().find(|c| c.index == ni) {
+                let name_range = (nc.node.start_byte(), nc.node.end_byte());
+                if !seen_names.insert(name_range) {
+                    continue;
+                }
+            }
+        }
+
+        let info = match handler.classify_node(item_node, source) {
+            Some(i) => i,
+            None => continue,
+        };
+
+        let visibility = handler.visibility(item_node, source);
+        if pub_only && !matches!(visibility, Visibility::Public) {
+            continue;
+        }
+
+        let (_, line_start) = find_attr_start(item_node);
+        let line_end = item_node.end_position().row + 1;
+
+        let is_container = matches!(
+            info.kind,
+            ItemKind::Class | ItemKind::Impl | ItemKind::Trait
+        );
+
+        if is_container {
+            // For containers: show header + member signatures
+            let content = build_container_outline(source, item_node, handler, pub_only, language);
+            items_map.entry(line_start).or_insert(Item {
+                kind: info.kind,
+                name: info.name,
+                visibility,
+                line_start,
+                line_end,
+                signature: None,
+                body: None,
+                content,
+                line_mappings: None,
+            });
+        } else if matches!(info.kind, ItemKind::Function | ItemKind::Method) {
+            // Functions: show signature with docstring
+            let docstring = get_docstring(source, item_node);
+            let sig = handler.signature(item_node, source);
+            let content = if let Some(doc) = docstring {
+                format!("{}\n{}", doc, sig)
+            } else {
+                sig.clone()
+            };
+            items_map.entry(line_start).or_insert(Item {
+                kind: info.kind,
+                name: info.name,
+                visibility,
+                line_start,
+                line_end,
+                signature: Some(sig),
+                body: None,
+                content,
+                line_mappings: None,
+            });
+        } else if matches!(info.kind, ItemKind::Struct | ItemKind::Enum) {
+            // Structs/enums: show full definition (fields are part of the type signature)
+            let (effective_start_byte, _) = find_attr_start(item_node);
+            let text = &source[effective_start_byte..item_node.end_byte()];
+            let docstring = get_docstring(source, item_node);
+            let content = if let Some(doc) = docstring {
+                format!("{}\n{}", doc, text)
+            } else {
+                text.to_string()
+            };
+            items_map.entry(line_start).or_insert(Item {
+                kind: info.kind,
+                name: info.name,
+                visibility,
+                line_start,
+                line_end,
+                signature: None,
+                body: None,
+                content,
+                line_mappings: None,
+            });
+        } else if matches!(info.kind, ItemKind::TypeAlias | ItemKind::Const | ItemKind::Static) {
+            // Type aliases, constants, statics: show as-is
+            let (effective_start_byte, _) = find_attr_start(item_node);
+            let text = &source[effective_start_byte..item_node.end_byte()];
+            let docstring = get_docstring(source, item_node);
+            let content = if let Some(doc) = docstring {
+                format!("{}\n{}", doc, text)
+            } else {
+                text.to_string()
+            };
+            items_map.entry(line_start).or_insert(Item {
+                kind: info.kind,
+                name: info.name,
+                visibility,
+                line_start,
+                line_end,
+                signature: None,
+                body: None,
+                content,
+                line_mappings: None,
+            });
+        } else if matches!(info.kind, ItemKind::Use) {
+            // Imports: include as-is
+            let text = &source[item_node.start_byte()..item_node.end_byte()];
+            items_map.entry(line_start).or_insert(Item {
+                kind: info.kind,
+                name: info.name,
+                visibility,
+                line_start,
+                line_end,
+                signature: None,
+                body: None,
+                content: text.to_string(),
+                line_mappings: None,
+            });
+        }
+        // Skip other kinds (Mod, MacroDef) — could add later
+    }
+
+    items_map.into_values().collect()
+}
+
+/// Build outline content for a container (class/impl/trait).
+/// Shows the container header, then each member's signature.
+fn build_container_outline(
+    source: &str,
+    item_node: Node,
+    handler: &dyn LanguageHandler,
+    pub_only: bool,
+    _language: Language,
+) -> String {
+    let mut lines = Vec::new();
+
+    // Get the container header (everything before the body block)
+    let inner_node = if item_node.kind() == "export_statement" {
+        let mut walk = item_node.walk();
+        item_node.named_children(&mut walk)
+            .find(|c| c.kind() != "decorator" && c.kind() != "comment")
+            .unwrap_or(item_node)
+    } else {
+        item_node
+    };
+
+    // Container docstring
+    if let Some(doc) = get_docstring(source, item_node) {
+        lines.push(doc);
+    }
+
+    // Build header: everything up to (but not including) the body
+    let body_field = handler.body_field_name();
+    let header = if let Some(body) = inner_node.child_by_field_name(body_field) {
+        let header_text = source[inner_node.start_byte()..body.start_byte()].trim_end();
+        format!("{} {{", header_text)
+    } else {
+        source[inner_node.start_byte()..inner_node.end_byte()].to_string()
+    };
+
+    // For Rust impl blocks that have attrs on the outer node
+    let (effective_start_byte, _) = find_attr_start(item_node);
+    if effective_start_byte < inner_node.start_byte() {
+        let attrs = source[effective_start_byte..inner_node.start_byte()].trim_end();
+        lines.push(attrs.to_string());
+    }
+    lines.push(header);
+
+    // Collect child symbols
+    let children = handler.child_symbols(inner_node, source);
+    for child in &children {
+        let vis = handler.member_visibility(child.node, source);
+        if pub_only && !matches!(vis, Visibility::Public) {
+            continue;
+        }
+
+        // Get docstring for child
+        if let Some(doc) = get_docstring(source, child.node) {
+            // Indent docstring
+            for line in doc.lines() {
+                lines.push(format!("    {}", line));
+            }
+        }
+
+        if matches!(child.kind, ItemKind::Function | ItemKind::Method) {
+            let sig = handler.signature(child.node, source);
+            // Indent the signature
+            for (i, line) in sig.lines().enumerate() {
+                if i == 0 {
+                    lines.push(format!("    {}", line));
+                } else {
+                    lines.push(format!("    {}", line));
+                }
+            }
+        } else {
+            // Fields, consts, type aliases inside containers: show as-is
+            let text = &source[child.node.start_byte()..child.node.end_byte()];
+            for line in text.lines() {
+                lines.push(format!("    {}", line));
+            }
+        }
+        lines.push(String::new()); // blank line between members
+    }
+
+    // Remove trailing blank line if present
+    if lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+
+    lines.push("}".to_string());
+    lines.join("\n")
+}
+
+/// Extract docstring/comment immediately preceding a node.
+fn get_docstring(source: &str, node: Node) -> Option<String> {
+    // First check for attributes/decorators that precede
+    let effective_node = {
+        let mut current = node;
+        loop {
+            match current.prev_sibling() {
+                Some(prev) if prev.kind() == "attribute_item" || prev.kind() == "decorator" => {
+                    current = prev;
+                }
+                _ => break,
+            }
+        }
+        current
+    };
+
+    // Now look for comment(s) immediately before
+    let mut comments = Vec::new();
+    let mut current = effective_node;
+    loop {
+        match current.prev_sibling() {
+            Some(prev) => {
+                let kind = prev.kind();
+                if kind == "comment" || kind == "line_comment" || kind == "block_comment" {
+                    let text = &source[prev.start_byte()..prev.end_byte()];
+                    comments.push(text.to_string());
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+
+    if comments.is_empty() {
+        return None;
+    }
+
+    // Comments were collected in reverse order
+    comments.reverse();
+
+    // Only include doc comments (/// or /** or #) not regular // comments
+    let doc_comments: Vec<&String> = comments.iter().filter(|c| {
+        let trimmed = c.trim();
+        trimmed.starts_with("///")
+            || trimmed.starts_with("/**")
+            || trimmed.starts_with("* ")
+            || trimmed.starts_with("#")  // Python docstrings via comment nodes
+    }).collect();
+
+    if doc_comments.is_empty() {
+        // For TS/JS, also accept /** ... */ block comments
+        let all_doc = comments.iter().any(|c| c.trim().starts_with("/**"));
+        if all_doc {
+            return Some(comments.join("\n"));
+        }
+        return None;
+    }
+
+    Some(doc_comments.into_iter().cloned().collect::<Vec<_>>().join("\n"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub struct ProcessOptions {
     pub smart_depth: bool,
     pub symbol_depth: Option<usize>,
     pub exclude: Vec<String>,
+    pub outline: bool,
 }
 
 /// Process a file or directory and return formatted output
@@ -249,6 +250,7 @@ fn process_file(
     signatures: bool,
     expand_methods: &[String],
     pub_only: bool,
+    outline: bool,
 ) -> Result<(Vec<Item>, usize, usize), CodehudError> {
     let source = fs::read_to_string(path)
         .map_err(|e| CodehudError::ReadError {
@@ -297,7 +299,11 @@ fn process_file(
             } else if expand_mode {
                 expand_with_dispatch(&block.content, &tree, symbols, block.language)
             } else {
-                extractor::interface::extract_filtered(&block.content, &tree, block.language, pub_only)
+                if outline {
+                    extractor::outline::extract_outline(&block.content, &tree, block.language, pub_only)
+                } else {
+                    extractor::interface::extract_filtered(&block.content, &tree, block.language, pub_only)
+                }
             };
             // Adjust line numbers to map back to original SFC file
             let offset = block.start_line - 1;
@@ -358,6 +364,8 @@ fn process_file(
         extractor::expand::extract_signatures(&source, &tree, class_name, expand_methods, language)
     } else if expand_mode {
         expand_with_dispatch(&source, &tree, symbols, language)
+    } else if outline {
+        extractor::outline::extract_outline(&source, &tree, language, pub_only)
     } else {
         extractor::interface::extract_filtered(&source, &tree, language, pub_only)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,10 @@ struct Cli {
     #[arg(long)]
     signatures: bool,
 
+    /// Outline mode: show signatures + docstrings + types without implementation bodies
+    #[arg(long, conflicts_with_all = ["signatures", "list_symbols", "search", "lines", "tree", "files", "references", "xrefs", "stats"])]
+    outline: bool,
+
     /// Truncate expanded symbol output after N lines
     #[arg(long = "max-lines")]
     max_lines: Option<usize>,
@@ -397,6 +401,7 @@ fn main() {
                 no_imports: cli.no_imports || (cli.list_symbols && !cli.imports),
                 smart_depth: cli.smart_depth,
                 exclude: cli.exclude,
+                outline: cli.outline,
             };
             
             match process_path(&path, options) {

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -95,6 +95,28 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
     Ok(output)
 }
 
+/// Format outline mode: signatures + docstrings without line numbers.
+pub fn format_outline(files: &[(String, Vec<Item>)]) -> Result<String, CodehudError> {
+    let mut output = String::new();
+
+    for (file_path, items) in files {
+        if items.is_empty() {
+            continue;
+        }
+
+        output.push_str(file_path);
+        output.push('\n');
+
+        for item in items {
+            output.push_str(&item.content);
+            output.push('\n');
+            output.push('\n');
+        }
+    }
+
+    Ok(output)
+}
+
 fn format_item(item: &Item) -> String {
     let mut result = String::new();
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -37,7 +37,7 @@ pub(crate) fn collect_and_extract(
     };
 
     if path.is_file() {
-        let (items, lines, bytes) = process_file(path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only)?;
+        let (items, lines, bytes) = process_file(path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline)?;
         return Ok(vec![FileItems {
             path: path.to_string_lossy().to_string(),
             items,
@@ -63,7 +63,7 @@ pub(crate) fn collect_and_extract(
         if options.no_tests && test_detect::is_test_file_any_language(&file_path) {
             continue;
         }
-        match process_file(&file_path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only) {
+        match process_file(&file_path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline) {
             Ok((items, lines, bytes)) => {
                 if expand_mode && !items.is_empty() {
                     for item in &items {
@@ -331,6 +331,11 @@ pub(crate) fn format_output(
 
     if options.stats {
         output::stats::format_output(filtered, source_sizes, options.format, options.summary_only)
+    } else if options.outline {
+        match options.format {
+            OutputFormat::Json => output::json::format_output(filtered),
+            OutputFormat::Plain => output::plain::format_outline(filtered),
+        }
     } else if options.list_symbols {
         match options.format {
             OutputFormat::Json => output::json::format_list_symbols(filtered),
@@ -384,6 +389,7 @@ mod tests {
             smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         }
     }
 

--- a/tests/display_names_test.rs
+++ b/tests/display_names_test.rs
@@ -18,6 +18,7 @@ fn list_options() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 }
 

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -19,6 +19,7 @@ fn default_options() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 }
 
@@ -44,6 +45,7 @@ fn exclude_single_directory() {
     let dir = setup_test_dir();
     let options = ProcessOptions {
         exclude: vec!["dist".to_string()],
+        outline: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -57,6 +59,7 @@ fn exclude_multiple_directories() {
     let dir = setup_test_dir();
     let options = ProcessOptions {
         exclude: vec!["dist".to_string(), "generated".to_string()],
+        outline: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -70,6 +73,7 @@ fn exclude_glob_pattern() {
     let dir = setup_test_dir();
     let options = ProcessOptions {
         exclude: vec!["*.js".to_string()],
+        outline: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -85,6 +89,7 @@ fn exclude_with_ext_filter() {
     let options = ProcessOptions {
         ext: vec!["rs".to_string()],
         exclude: vec!["src".to_string()],
+        outline: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -151,6 +156,7 @@ fn exclude_wildcard_path_pattern() {
 
     let options = ProcessOptions {
         exclude: vec!["*/migrations/*".to_string()],
+        outline: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -20,6 +20,7 @@ fn test_interface_mode_basic() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -54,6 +55,7 @@ fn test_expand_mode() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -85,6 +87,7 @@ fn test_expand_function() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -114,6 +117,7 @@ fn test_pub_filter() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -146,6 +150,7 @@ fn test_fns_filter() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -179,6 +184,7 @@ fn test_types_filter() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -213,6 +219,7 @@ fn test_combined_pub_fns() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -249,6 +256,7 @@ fn test_json_output() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -286,6 +294,7 @@ fn test_nonexistent_path() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -312,6 +321,7 @@ fn test_directory_mode() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -341,6 +351,7 @@ fn test_expand_nonexistent_symbol() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
     
@@ -372,6 +383,7 @@ fn test_no_tests_filter() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
 
@@ -408,6 +420,7 @@ fn test_no_tests_filter_disabled() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
 
@@ -438,6 +451,7 @@ fn test_stats_output_plain() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
 
@@ -469,6 +483,7 @@ fn test_stats_output_json() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
 
@@ -504,6 +519,7 @@ fn test_stats_with_directory() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     
 };
 
@@ -535,6 +551,7 @@ fn test_stats_summary_only_plain() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -567,6 +584,7 @@ fn test_stats_summary_only_json() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);

--- a/tests/javascript_test.rs
+++ b/tests/javascript_test.rs
@@ -20,6 +20,7 @@ fn opts() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 
 }

--- a/tests/list_symbols_test.rs
+++ b/tests/list_symbols_test.rs
@@ -32,6 +32,7 @@ fn default_options() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 }
 
@@ -69,6 +70,7 @@ fn test_list_symbols_smaller_than_interface() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let interface_output = process_path(FIXTURE_PATH, interface_opts).unwrap();
@@ -160,6 +162,7 @@ fn test_list_symbols_no_imports_excludes_use() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -178,6 +181,7 @@ fn test_list_symbols_without_no_imports_includes_use() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -252,6 +256,7 @@ fn test_list_symbols_no_imports_typescript() {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/imports_sample.ts", options).unwrap();
@@ -277,6 +282,7 @@ fn test_list_symbols_vue_sfc_depth_2_shows_class_members() {
     let options = ProcessOptions {
         symbol_depth: Some(2),
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -293,6 +299,7 @@ fn test_list_symbols_vue_sfc_depth_1_hides_class_members() {
     let options = ProcessOptions {
         symbol_depth: Some(1),
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -324,6 +331,7 @@ fn test_list_symbols_depth_2_shows_class_members() {
     let options = ProcessOptions {
         symbol_depth: Some(2),
         exclude: vec![],
+        outline: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/sample.ts", options).unwrap();
@@ -337,6 +345,7 @@ fn test_list_symbols_depth_2_json_includes_methods() {
     let options = ProcessOptions {
         symbol_depth: Some(2),
         exclude: vec![],
+        outline: false,
         format: OutputFormat::Json,
         ..default_options()
     };

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -24,6 +24,7 @@ fn default_options() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 }
 

--- a/tests/python_test.rs
+++ b/tests/python_test.rs
@@ -20,6 +20,7 @@ fn opts() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 
 }

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -20,6 +20,7 @@ fn opts() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 }
 

--- a/tests/symbol_not_found_test.rs
+++ b/tests/symbol_not_found_test.rs
@@ -20,6 +20,7 @@ fn default_options() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
         summary_only: false,
     }
 }

--- a/tests/typescript_test.rs
+++ b/tests/typescript_test.rs
@@ -20,6 +20,7 @@ fn opts() -> ProcessOptions {
         smart_depth: false,
         symbol_depth: None,
         exclude: vec![],
+        outline: false,
     }
 
 }


### PR DESCRIPTION
## Summary

Implements **Outline Mode** — a new `--outline` flag that shows signatures + docstrings + types without implementation bodies. This is the middle ground between `--list-symbols` (one-liner per symbol) and the default interface mode (everything with collapsed bodies).

### What it does

`codehud --outline src/lib.rs` outputs:
- Function/method signatures (no bodies)
- Docstrings/doc-comments above symbols
- Struct/enum/type definitions in full
- Container headers (impl/class/trait) with member signatures indented

### Composes with
- `--pub`, `--no-tests`, `--no-imports`, `--ext`, `--exclude`, `--depth`, `--json`, `--fns`, `--types`

### Mutually exclusive with
- `--signatures`, `--list-symbols`, `--search`, `--lines`, `--tree`, `--files`, `--references`, `--xrefs`, `--stats`

### Changes
- New `src/extractor/outline.rs` — core outline extraction logic
- Added `outline: bool` to `ProcessOptions`
- Added `--outline` clap flag with proper conflict declarations
- Added `format_outline()` in plain output (no line numbers, clean text)
- All existing tests pass (190 pass, 1 pre-existing unrelated failure)

Refs #5, refs #6