### PR TITLE
fix: repair test_search_toml_file test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codehud"
-version = "0.2.0"
+version = "0.0.1"
 dependencies = [
  "clap",
  "globset",

--- a/src/search.rs
+++ b/src/search.rs
@@ -908,7 +908,7 @@ impl Foo {
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "Cargo.toml", "[package]\nname = \"codehud\"\nversion = \"1.0.0\"\n");
         let opts = SearchOptions {
-            pattern: "codeview".to_string(),
+            pattern: "codehud".to_string(),
             regex: false,
             case_insensitive: false,
             depth: None,


### PR DESCRIPTION
The test was searching for "codeview" but the test file content contained "codehud", so the search pattern never matched. Fixed the pattern to match the actual file content.