### PR TITLE
fix: use combined checksums file in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ main() {
   base_url="https://github.com/${REPO}/releases/download/${version}"
   tarball_name="codehud-${version}-${target}.tar.gz"
   tarball_url="${base_url}/${tarball_name}"
-  checksum_url="${base_url}/${tarball_name}.sha256"
+  checksums_url="${base_url}/codehud-${version}-checksums.sha256"
   
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' EXIT
@@ -77,11 +77,12 @@ main() {
   echo "Downloading ${tarball_name}..."
   curl -fsSL "$tarball_url" -o "$tmpdir/$tarball_name"
   
-  echo "Downloading checksum..."
-  curl -fsSL "$checksum_url" -o "$tmpdir/$tarball_name.sha256"
+  echo "Downloading checksums..."
+  curl -fsSL "$checksums_url" -o "$tmpdir/checksums.sha256"
   
   echo "Verifying checksum..."
   cd "$tmpdir"
+  grep "$tarball_name" checksums.sha256 > "$tarball_name.sha256"
   verify_checksum "$tarball_name" "$tarball_name.sha256"
   
   echo "Extracting..."


### PR DESCRIPTION
Fixes the checksum verification in the install script. Previously it tried to download per-file checksums (`codehud-v0.0.1-x86_64-unknown-linux-musl.tar.gz.sha256`), but the release only publishes a combined checksums file (`codehud-v0.0.1-checksums.sha256`).

The fix:
- Downloads the combined `codehud-${version}-checksums.sha256` file
- Extracts the relevant line for the target tarball using `grep`
- Writes that line to a temp file for verification
- Keeps the `verify_checksum` function unchanged

Tested successfully on Linux x86_64.