### PR TITLE
feat: add install-skill core subcommands and skill content

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+pub mod skill;
 pub(crate) mod parser;
 pub(crate) mod extractor;
 pub(crate) mod languages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use codehud::{detect_language, editor, process_path, search, tree, ProcessOptions, OutputFormat, Language, CodehudError};
 use codehud::editor::{BatchEdit, EditResult};
+use codehud::skill;
 use std::{fs, io::{self, Read}, path::Path, process};
 
 #[derive(Parser)]
@@ -150,6 +151,23 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Install codehud skill for a coding platform
+    InstallSkill {
+        /// Platform to install for (e.g. openclaw, claude-code, codex, cursor, aider)
+        #[arg(required_unless_present = "list")]
+        platform: Option<String>,
+
+        /// List available platforms
+        #[arg(long)]
+        list: bool,
+    },
+
+    /// Uninstall codehud skill from a coding platform
+    UninstallSkill {
+        /// Platform to uninstall from
+        platform: String,
+    },
+
     /// Edit a symbol in a file
     Edit {
         /// File to edit
@@ -209,6 +227,22 @@ fn main() {
     let cli = Cli::parse();
     
     match cli.command {
+        Some(Commands::InstallSkill { platform, list }) => {
+            if list {
+                skill::list_platforms();
+            } else if let Some(p) = platform {
+                if let Err(e) = skill::install(&p) {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Some(Commands::UninstallSkill { platform }) => {
+            if let Err(e) = skill::uninstall(&platform) {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
         Some(Commands::Edit { file, symbol, replace, replace_body, stdin, delete, add_after, add_before, append, prepend, batch, dry_run, json }) => {
             if let Err(e) = handle_edit(&file, &symbol, EditOptions { replace, replace_body, stdin, delete, add_after, add_before, append, prepend, batch, dry_run, json }) {
                 eprintln!("Error: {}", e);

--- a/src/skill/aider.rs
+++ b/src/skill/aider.rs
@@ -1,0 +1,17 @@
+use super::{PlatformAdapter, SkillError};
+
+pub struct AiderAdapter;
+
+impl PlatformAdapter for AiderAdapter {
+    fn install(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Aider".to_string()))
+    }
+
+    fn uninstall(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Aider".to_string()))
+    }
+
+    fn name(&self) -> &'static str {
+        "Aider"
+    }
+}

--- a/src/skill/claude_code.rs
+++ b/src/skill/claude_code.rs
@@ -1,0 +1,17 @@
+use super::{PlatformAdapter, SkillError};
+
+pub struct ClaudeCodeAdapter;
+
+impl PlatformAdapter for ClaudeCodeAdapter {
+    fn install(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Claude Code".to_string()))
+    }
+
+    fn uninstall(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Claude Code".to_string()))
+    }
+
+    fn name(&self) -> &'static str {
+        "Claude Code"
+    }
+}

--- a/src/skill/codex.rs
+++ b/src/skill/codex.rs
@@ -1,0 +1,17 @@
+use super::{PlatformAdapter, SkillError};
+
+pub struct CodexAdapter;
+
+impl PlatformAdapter for CodexAdapter {
+    fn install(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Codex".to_string()))
+    }
+
+    fn uninstall(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Codex".to_string()))
+    }
+
+    fn name(&self) -> &'static str {
+        "Codex"
+    }
+}

--- a/src/skill/content.rs
+++ b/src/skill/content.rs
@@ -1,0 +1,13 @@
+/// The shared codehud skill content, compiled into the binary.
+pub const SKILL_CONTENT: &str = include_str!("skill_content.md");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_content_is_not_empty() {
+        assert!(!SKILL_CONTENT.is_empty());
+        assert!(SKILL_CONTENT.contains("codehud"));
+    }
+}

--- a/src/skill/cursor.rs
+++ b/src/skill/cursor.rs
@@ -1,0 +1,17 @@
+use super::{PlatformAdapter, SkillError};
+
+pub struct CursorAdapter;
+
+impl PlatformAdapter for CursorAdapter {
+    fn install(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Cursor".to_string()))
+    }
+
+    fn uninstall(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("Cursor".to_string()))
+    }
+
+    fn name(&self) -> &'static str {
+        "Cursor"
+    }
+}

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -1,0 +1,78 @@
+pub mod content;
+mod openclaw;
+mod claude_code;
+mod codex;
+mod cursor;
+mod aider;
+
+use std::fmt;
+
+/// Trait that each platform adapter implements.
+pub trait PlatformAdapter {
+    /// Install the codehud skill for this platform.
+    fn install(&self) -> Result<(), SkillError>;
+    /// Uninstall the codehud skill for this platform.
+    fn uninstall(&self) -> Result<(), SkillError>;
+    /// Human-readable platform name.
+    fn name(&self) -> &'static str;
+}
+
+#[derive(Debug)]
+pub enum SkillError {
+    NotImplemented(String),
+    Io(std::io::Error),
+    UnknownPlatform(String),
+}
+
+impl fmt::Display for SkillError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SkillError::NotImplemented(p) => write!(f, "{} adapter not yet implemented (see https://github.com/AvoCloud/codeview/issues)", p),
+            SkillError::Io(e) => write!(f, "IO error: {}", e),
+            SkillError::UnknownPlatform(p) => {
+                write!(f, "Unknown platform '{}'. Available platforms: {}", p, PLATFORMS.join(", "))
+            }
+        }
+    }
+}
+
+impl From<std::io::Error> for SkillError {
+    fn from(e: std::io::Error) -> Self {
+        SkillError::Io(e)
+    }
+}
+
+/// All supported platform names.
+pub const PLATFORMS: &[&str] = &["openclaw", "claude-code", "codex", "cursor", "aider"];
+
+/// List all available platforms to stdout.
+pub fn list_platforms() {
+    println!("Available platforms:");
+    for p in PLATFORMS {
+        println!("  {}", p);
+    }
+}
+
+/// Get the adapter for a given platform name.
+fn get_adapter(platform: &str) -> Result<Box<dyn PlatformAdapter>, SkillError> {
+    match platform {
+        "openclaw" => Ok(Box::new(openclaw::OpenClawAdapter)),
+        "claude-code" => Ok(Box::new(claude_code::ClaudeCodeAdapter)),
+        "codex" => Ok(Box::new(codex::CodexAdapter)),
+        "cursor" => Ok(Box::new(cursor::CursorAdapter)),
+        "aider" => Ok(Box::new(aider::AiderAdapter)),
+        _ => Err(SkillError::UnknownPlatform(platform.to_string())),
+    }
+}
+
+/// Install skill for the given platform.
+pub fn install(platform: &str) -> Result<(), SkillError> {
+    let adapter = get_adapter(platform)?;
+    adapter.install()
+}
+
+/// Uninstall skill for the given platform.
+pub fn uninstall(platform: &str) -> Result<(), SkillError> {
+    let adapter = get_adapter(platform)?;
+    adapter.uninstall()
+}

--- a/src/skill/openclaw.rs
+++ b/src/skill/openclaw.rs
@@ -1,0 +1,17 @@
+use super::{PlatformAdapter, SkillError};
+
+pub struct OpenClawAdapter;
+
+impl PlatformAdapter for OpenClawAdapter {
+    fn install(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("OpenClaw".to_string()))
+    }
+
+    fn uninstall(&self) -> Result<(), SkillError> {
+        Err(SkillError::NotImplemented("OpenClaw".to_string()))
+    }
+
+    fn name(&self) -> &'static str {
+        "OpenClaw"
+    }
+}

--- a/src/skill/skill_content.md
+++ b/src/skill/skill_content.md
@@ -1,0 +1,44 @@
+# codehud — Structural Code Intelligence
+
+codehud extracts structural information from code using Tree-sitter. Use it instead of grep/find for understanding codebases.
+
+## Binary
+`codehud` — ensure it's on PATH. Install: `cargo install codehud` or via install.sh.
+
+## Workflow
+
+### 1. Orient — understand the project
+```bash
+codehud --stats .                 # Language breakdown, file counts
+codehud --smart-depth .           # Adaptive directory tree
+```
+
+### 2. Explore structure — find what's in a file
+```bash
+codehud --outline src/main.rs     # Functions, structs, impls — signatures only
+codehud --list-symbols src/       # All symbols across directory
+```
+
+### 3. Drill into specifics
+```bash
+codehud src/parser.rs             # Full structural view with bodies
+codehud src/parser.rs::parse_expr # Single symbol expansion
+```
+
+### 4. Search and cross-reference
+```bash
+codehud --search "Config" .       # Find symbols matching pattern
+codehud --xrefs "parse_expr" .    # Where is this symbol used?
+```
+
+### 5. Review changes
+```bash
+codehud --diff                    # Structural diff vs git HEAD
+codehud --diff --staged           # Staged changes only
+```
+
+## Best Practices
+- Start with `--stats` + `--smart-depth` on new codebases — don't read files blindly
+- Use `--outline` before reading full files — often the signature is enough
+- Prefer `--xrefs` over grep for finding symbol usage
+- Use `--diff` to understand what changed structurally (ignores formatting noise)

--- a/tests/skill_test.rs
+++ b/tests/skill_test.rs
@@ -1,0 +1,65 @@
+use std::process::Command;
+
+fn codehud() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_codehud"))
+}
+
+#[test]
+fn install_skill_list_shows_platforms() {
+    let output = codehud()
+        .args(["install-skill", "--list"])
+        .output()
+        .expect("failed to run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("openclaw"));
+    assert!(stdout.contains("claude-code"));
+    assert!(stdout.contains("codex"));
+    assert!(stdout.contains("cursor"));
+    assert!(stdout.contains("aider"));
+}
+
+#[test]
+fn install_skill_unknown_platform_gives_error() {
+    let output = codehud()
+        .args(["install-skill", "foobar"])
+        .output()
+        .expect("failed to run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown platform 'foobar'"));
+    assert!(stderr.contains("Available platforms"));
+}
+
+#[test]
+fn install_uninstall_stubs_return_not_implemented() {
+    // All adapters are stubs for now, so install should fail with "not yet implemented"
+    for platform in &["openclaw", "claude-code", "codex", "cursor", "aider"] {
+        let output = codehud()
+            .args(["install-skill", platform])
+            .output()
+            .expect("failed to run");
+        assert!(!output.status.success(), "expected failure for {}", platform);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("not yet implemented"), "platform {} stderr: {}", platform, stderr);
+    }
+}
+
+#[test]
+fn uninstall_skill_unknown_platform_gives_error() {
+    let output = codehud()
+        .args(["uninstall-skill", "foobar"])
+        .output()
+        .expect("failed to run");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown platform 'foobar'"));
+}
+
+#[test]
+fn skill_content_compiled_in() {
+    // Verify the content module works
+    assert!(!codehud::skill::content::SKILL_CONTENT.is_empty());
+    assert!(codehud::skill::content::SKILL_CONTENT.contains("codehud"));
+    assert!(codehud::skill::content::SKILL_CONTENT.contains("Tree-sitter"));
+}


### PR DESCRIPTION
Implements #21

## Changes
- **Shared skill content** (`src/skill/content.rs`) — compiled-in markdown via `include_str!`
- **Platform adapter trait** — `PlatformAdapter` with `install()` / `uninstall()` / `name()`
- **CLI subcommands**: `install-skill <platform>`, `install-skill --list`, `uninstall-skill <platform>`
- **Module structure**: `src/skill/mod.rs` + stub adapters for openclaw, claude-code, codex, cursor, aider
- **Integration tests**: 5 tests covering list, unknown platform error, stub behavior, content compilation

All adapters return "not yet implemented" — real implementations are in #16-#20.

Closes #21