### PR TITLE
feat: implement OpenClaw install-skill adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ name = "codehud"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "dirs",
  "globset",
  "ignore",
  "rayon",
@@ -191,6 +192,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +251,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -336,6 +369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +407,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "prettyplease"
@@ -417,6 +466,17 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -556,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -669,6 +729,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tree-sitter = "0.26"
 tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 tree-sitter-python = "0.23"
+dirs = "6"
 tree-sitter-javascript = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/skill/openclaw.rs
+++ b/src/skill/openclaw.rs
@@ -1,14 +1,64 @@
 use super::{PlatformAdapter, SkillError};
+use super::content::SKILL_CONTENT;
+use std::fs;
+use std::path::PathBuf;
 
 pub struct OpenClawAdapter;
 
+const FRONTMATTER: &str = r#"---
+name: codehud
+description: "Tree-sitter powered structural code intelligence. Use for code exploration, symbol lookup, cross-references, and structural diff."
+metadata:
+  openclaw:
+    emoji: "🔬"
+    requires:
+      bins: ["codehud"]
+    install:
+      - id: cargo
+        kind: shell
+        command: "cargo install codehud"
+        bins: ["codehud"]
+        label: "Install codehud (cargo)"
+      - id: script
+        kind: shell
+        command: "curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh"
+        bins: ["codehud"]
+        label: "Install codehud (install script)"
+---
+"#;
+
+fn skill_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("could not determine home directory")
+        .join(".openclaw/workspace/skills/codehud")
+}
+
 impl PlatformAdapter for OpenClawAdapter {
     fn install(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("OpenClaw".to_string()))
+        let dir = skill_dir();
+        fs::create_dir_all(&dir)?;
+        let path = dir.join("SKILL.md");
+        let content = format!("{}\n{}\n", FRONTMATTER.trim(), SKILL_CONTENT.trim());
+        fs::write(&path, content)?;
+        println!("Installed codehud skill to {}", path.display());
+        Ok(())
     }
 
     fn uninstall(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("OpenClaw".to_string()))
+        let dir = skill_dir();
+        let path = dir.join("SKILL.md");
+        if path.exists() {
+            fs::remove_file(&path)?;
+            println!("Removed {}", path.display());
+        }
+        // Remove directory if empty
+        if dir.exists() {
+            if fs::read_dir(&dir)?.next().is_none() {
+                fs::remove_dir(&dir)?;
+                println!("Removed empty directory {}", dir.display());
+            }
+        }
+        Ok(())
     }
 
     fn name(&self) -> &'static str {

--- a/tests/skill_test.rs
+++ b/tests/skill_test.rs
@@ -33,8 +33,8 @@ fn install_skill_unknown_platform_gives_error() {
 
 #[test]
 fn install_uninstall_stubs_return_not_implemented() {
-    // All adapters are stubs for now, so install should fail with "not yet implemented"
-    for platform in &["openclaw", "claude-code", "codex", "cursor", "aider"] {
+    // Stub adapters should fail with "not yet implemented"
+    for platform in &["claude-code", "codex", "cursor", "aider"] {
         let output = codehud()
             .args(["install-skill", platform])
             .output()
@@ -43,6 +43,40 @@ fn install_uninstall_stubs_return_not_implemented() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(stderr.contains("not yet implemented"), "platform {} stderr: {}", platform, stderr);
     }
+}
+
+#[test]
+fn openclaw_install_and_uninstall() {
+    // Install
+    let output = codehud()
+        .args(["install-skill", "openclaw"])
+        .output()
+        .expect("failed to run");
+    assert!(output.status.success(), "install failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    let skill_path = dirs::home_dir().unwrap().join(".openclaw/workspace/skills/codehud/SKILL.md");
+    assert!(skill_path.exists(), "SKILL.md should exist after install");
+
+    let content = std::fs::read_to_string(&skill_path).unwrap();
+    assert!(content.starts_with("---"));
+    assert!(content.contains("name: codehud"));
+    assert!(content.contains("Tree-sitter"));
+    assert!(content.contains("codehud"));
+
+    // Idempotent re-install
+    let output2 = codehud()
+        .args(["install-skill", "openclaw"])
+        .output()
+        .expect("failed to run");
+    assert!(output2.status.success());
+
+    // Uninstall
+    let output3 = codehud()
+        .args(["uninstall-skill", "openclaw"])
+        .output()
+        .expect("failed to run");
+    assert!(output3.status.success(), "uninstall failed: {}", String::from_utf8_lossy(&output3.stderr));
+    assert!(!skill_path.exists(), "SKILL.md should be removed after uninstall");
 }
 
 #[test]


### PR DESCRIPTION
Implements #16

- `codehud install-skill openclaw` writes `~/.openclaw/workspace/skills/codehud/SKILL.md` with YAML frontmatter + shared skill content
- `codehud uninstall-skill openclaw` removes the file and empty directory
- Idempotent (safe to re-run)
- Added integration test for install/uninstall cycle
- All 216 tests pass