### PR TITLE
feat: add install-agent/uninstall-agent subcommands (refs #36)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,0 +1,79 @@
+mod openclaw;
+
+use std::fmt;
+
+/// Trait that each platform adapter implements for agent registration.
+pub trait AgentAdapter {
+    /// Install/register the codehud agent for this platform.
+    fn install(&self) -> Result<(), AgentError>;
+    /// Uninstall/remove the codehud agent from this platform.
+    fn uninstall(&self, force: bool) -> Result<(), AgentError>;
+    /// Human-readable platform name.
+    fn name(&self) -> &'static str;
+}
+
+#[derive(Debug)]
+pub enum AgentError {
+    NotImplemented(String),
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    UnknownPlatform(String),
+    Config(String),
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AgentError::NotImplemented(p) => write!(f, "{} agent adapter not yet implemented", p),
+            AgentError::Io(e) => write!(f, "IO error: {}", e),
+            AgentError::Json(e) => write!(f, "JSON error: {}", e),
+            AgentError::UnknownPlatform(p) => {
+                write!(f, "Unknown platform '{}'. Available platforms: {}", p, PLATFORMS.join(", "))
+            }
+            AgentError::Config(msg) => write!(f, "Config error: {}", msg),
+        }
+    }
+}
+
+impl From<std::io::Error> for AgentError {
+    fn from(e: std::io::Error) -> Self {
+        AgentError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for AgentError {
+    fn from(e: serde_json::Error) -> Self {
+        AgentError::Json(e)
+    }
+}
+
+/// All supported platform names for agent installation.
+pub const PLATFORMS: &[&str] = &["openclaw"];
+
+/// List all available platforms to stdout.
+pub fn list_platforms() {
+    println!("Available platforms:");
+    for p in PLATFORMS {
+        println!("  {}", p);
+    }
+}
+
+/// Get the adapter for a given platform name.
+fn get_adapter(platform: &str) -> Result<Box<dyn AgentAdapter>, AgentError> {
+    match platform {
+        "openclaw" => Ok(Box::new(openclaw::OpenClawAdapter)),
+        _ => Err(AgentError::UnknownPlatform(platform.to_string())),
+    }
+}
+
+/// Install agent for the given platform.
+pub fn install(platform: &str) -> Result<(), AgentError> {
+    let adapter = get_adapter(platform)?;
+    adapter.install()
+}
+
+/// Uninstall agent for the given platform.
+pub fn uninstall(platform: &str, force: bool) -> Result<(), AgentError> {
+    let adapter = get_adapter(platform)?;
+    adapter.uninstall(force)
+}

--- a/src/agent/openclaw.rs
+++ b/src/agent/openclaw.rs
@@ -1,0 +1,329 @@
+use super::{AgentAdapter, AgentError};
+use crate::skill::content::SKILL_CONTENT;
+use std::fs;
+use std::path::PathBuf;
+
+pub struct OpenClawAdapter;
+
+const AGENT_ID: &str = "codehud";
+
+const SOUL_MD: &str = r#"# SOUL.md — Code HUD
+
+You are a code exploration specialist. You use the `codehud` CLI for all structural code intelligence.
+
+## Core Principles
+
+- **Structure over raw text** — always prefer `codehud` outlines, symbol lists, and references over reading entire files
+- **Concise and technical** — no filler, no pleasantries, just precise structural answers
+- **Stay focused** — you are not a general-purpose assistant. You explore code. That's it.
+
+## How You Work
+
+1. Use `codehud <path>` for file/directory overviews
+2. Use `codehud <path> <symbol>` to expand specific symbols
+3. Use `codehud <path> --outline` for signatures and docstrings
+4. Use `codehud <path> --search <pattern>` for structural search
+5. Use `codehud <path> --references <symbol>` for reference finding
+6. Use `codehud <path> --xrefs <symbol>` for cross-file references
+7. Use `codehud <path> --diff` for structural diffs
+
+## Vibe
+
+Methodical. Precise. Like a well-indexed codebase — everything in its place, nothing wasted.
+"#;
+
+const IDENTITY_MD: &str = r#"# IDENTITY.md
+
+- **Name:** Code HUD
+- **Creature:** Code exploration specialist
+- **Emoji:** 🔬
+- **Vibe:** Precise, structural, focused. A code microscope, not a Swiss army knife.
+"#;
+
+const AGENTS_MD: &str = r#"# AGENTS.md — Code HUD
+
+This agent uses the `codehud` CLI for structural code intelligence.
+
+## Available Commands
+
+| Command | Description |
+|---|---|
+| `codehud <path>` | File/directory overview with collapsed symbols |
+| `codehud <path> <symbol>` | Expand a specific symbol |
+| `codehud <path> --outline` | Signatures + docstrings without bodies |
+| `codehud <path> --list-symbols` | Compact symbol listing |
+| `codehud <path> --search <pat>` | Structural search with context |
+| `codehud <path> --references <sym>` | Find all references to a symbol |
+| `codehud <path> --xrefs <sym>` | Cross-file reference search |
+| `codehud <path> --diff` | Structural diff against git HEAD |
+| `codehud <path> --tree` | Smart directory tree |
+| `codehud edit <file> <sym> --replace <code>` | AST-aware code editing |
+
+## Workflow
+
+1. Start with `--tree` or `--files` to understand project layout
+2. Use outlines to understand module structure
+3. Expand specific symbols for implementation details
+4. Use references/xrefs to trace dependencies
+"#;
+
+const SKILL_FRONTMATTER: &str = r#"---
+name: codehud
+description: "Tree-sitter powered structural code intelligence. Use for code exploration, symbol lookup, cross-references, and structural diff."
+metadata:
+  openclaw:
+    emoji: "🔬"
+    requires:
+      bins: ["codehud"]
+    install:
+      - id: cargo
+        kind: shell
+        command: "cargo install codehud"
+        bins: ["codehud"]
+        label: "Install codehud (cargo)"
+      - id: script
+        kind: shell
+        command: "curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh"
+        bins: ["codehud"]
+        label: "Install codehud (install script)"
+---
+"#;
+
+fn home_dir() -> PathBuf {
+    dirs::home_dir().expect("could not determine home directory")
+}
+
+fn workspace_dir() -> PathBuf {
+    home_dir().join(".openclaw/workspace-codehud")
+}
+
+fn config_path() -> PathBuf {
+    home_dir().join(".openclaw/openclaw.json")
+}
+
+fn state_dir() -> PathBuf {
+    home_dir().join(".openclaw/agents/codehud/agent")
+}
+
+/// Read the openclaw.json config as a serde_json::Value.
+fn read_config() -> Result<serde_json::Value, AgentError> {
+    let path = config_path();
+    if !path.exists() {
+        return Err(AgentError::Config(format!(
+            "Config file not found: {}. Is OpenClaw installed?",
+            path.display()
+        )));
+    }
+    let content = fs::read_to_string(&path)?;
+    let config: serde_json::Value = serde_json::from_str(&content)?;
+    Ok(config)
+}
+
+/// Write the config back to openclaw.json with pretty formatting.
+fn write_config(config: &serde_json::Value) -> Result<(), AgentError> {
+    let content = serde_json::to_string_pretty(config)?;
+    fs::write(config_path(), content)?;
+    Ok(())
+}
+
+/// Add the codehud agent entry to agents.list[] if not already present.
+fn add_agent_to_config(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+    let agents_list = config
+        .pointer_mut("/agents/list")
+        .and_then(|v| v.as_array_mut())
+        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+
+    // Check if already present
+    for entry in agents_list.iter() {
+        if entry.get("id").and_then(|v| v.as_str()) == Some(AGENT_ID) {
+            return Ok(false); // already exists
+        }
+    }
+
+    let agent_entry = serde_json::json!({
+        "id": AGENT_ID,
+        "name": "Code HUD",
+        "workspace": "~/.openclaw/workspace-codehud",
+        "model": "anthropic/claude-sonnet-4-5",
+        "skills": ["codehud"],
+        "identity": {
+            "name": "Code HUD",
+            "emoji": "🔬"
+        },
+        "tools": {
+            "allow": ["exec", "read", "write", "edit", "web_search", "web_fetch"]
+        }
+    });
+
+    agents_list.push(agent_entry);
+    Ok(true)
+}
+
+/// Remove the codehud agent entry from agents.list[].
+fn remove_agent_from_config(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+    let agents_list = config
+        .pointer_mut("/agents/list")
+        .and_then(|v| v.as_array_mut())
+        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+
+    let before = agents_list.len();
+    agents_list.retain(|entry| {
+        entry.get("id").and_then(|v| v.as_str()) != Some(AGENT_ID)
+    });
+    Ok(agents_list.len() < before)
+}
+
+/// Add "codehud" to the main agent's subagents.allowAgents array.
+fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+    let agents_list = config
+        .pointer_mut("/agents/list")
+        .and_then(|v| v.as_array_mut())
+        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+
+    // Find the main/default agent
+    for entry in agents_list.iter_mut() {
+        let is_main = entry.get("default").and_then(|v| v.as_bool()).unwrap_or(false)
+            || entry.get("id").and_then(|v| v.as_str()) == Some("main");
+
+        if is_main {
+            // Navigate to subagents.allowAgents, creating if needed
+            let subagents = entry
+                .as_object_mut()
+                .unwrap()
+                .entry("subagents")
+                .or_insert_with(|| serde_json::json!({}));
+            let allow = subagents
+                .as_object_mut()
+                .unwrap()
+                .entry("allowAgents")
+                .or_insert_with(|| serde_json::json!([]));
+            let arr = allow.as_array_mut().unwrap();
+
+            if arr.iter().any(|v| v.as_str() == Some(AGENT_ID)) {
+                return Ok(false); // already present
+            }
+            arr.push(serde_json::Value::String(AGENT_ID.to_string()));
+            return Ok(true);
+        }
+    }
+    Ok(false) // no main agent found
+}
+
+/// Remove "codehud" from the main agent's subagents.allowAgents array.
+fn remove_from_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+    let agents_list = config
+        .pointer_mut("/agents/list")
+        .and_then(|v| v.as_array_mut())
+        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+
+    for entry in agents_list.iter_mut() {
+        let is_main = entry.get("default").and_then(|v| v.as_bool()).unwrap_or(false)
+            || entry.get("id").and_then(|v| v.as_str()) == Some("main");
+
+        if is_main {
+            if let Some(arr) = entry
+                .pointer_mut("/subagents/allowAgents")
+                .and_then(|v| v.as_array_mut())
+            {
+                let before = arr.len();
+                arr.retain(|v| v.as_str() != Some(AGENT_ID));
+                return Ok(arr.len() < before);
+            }
+            return Ok(false);
+        }
+    }
+    Ok(false)
+}
+
+impl AgentAdapter for OpenClawAdapter {
+    fn install(&self) -> Result<(), AgentError> {
+        let ws = workspace_dir();
+
+        // 1. Create workspace and write files
+        fs::create_dir_all(&ws)?;
+        fs::write(ws.join("SOUL.md"), SOUL_MD.trim())?;
+        fs::write(ws.join("IDENTITY.md"), IDENTITY_MD.trim())?;
+        fs::write(ws.join("AGENTS.md"), AGENTS_MD.trim())?;
+        println!("✓ Created workspace at {}", ws.display());
+
+        // 2. Install codehud skill into agent workspace
+        let skill_dir = ws.join("skills/codehud");
+        fs::create_dir_all(&skill_dir)?;
+        let skill_content = format!("{}\n{}\n", SKILL_FRONTMATTER.trim(), SKILL_CONTENT.trim());
+        fs::write(skill_dir.join("SKILL.md"), skill_content)?;
+        println!("✓ Installed codehud skill to {}", skill_dir.display());
+
+        // 3. Create agent state directory
+        let state = state_dir();
+        fs::create_dir_all(&state)?;
+        println!("✓ Created agent state dir at {}", state.display());
+
+        // 4. Register in openclaw.json
+        let mut config = read_config()?;
+        let added = add_agent_to_config(&mut config)?;
+        if added {
+            println!("✓ Registered codehud agent in openclaw.json");
+        } else {
+            println!("  codehud agent already registered in openclaw.json");
+        }
+
+        let allowlisted = add_to_spawn_allowlist(&mut config)?;
+        if allowlisted {
+            println!("✓ Added codehud to main agent spawn allowlist");
+        } else {
+            println!("  codehud already in main agent spawn allowlist");
+        }
+
+        write_config(&config)?;
+
+        println!();
+        println!("Run 'openclaw gateway restart' to activate the agent");
+        Ok(())
+    }
+
+    fn uninstall(&self, force: bool) -> Result<(), AgentError> {
+        // 1. Update openclaw.json
+        let mut config = read_config()?;
+        let removed = remove_agent_from_config(&mut config)?;
+        if removed {
+            println!("✓ Removed codehud agent from openclaw.json");
+        } else {
+            println!("  codehud agent not found in openclaw.json");
+        }
+
+        let unlisted = remove_from_spawn_allowlist(&mut config)?;
+        if unlisted {
+            println!("✓ Removed codehud from main agent spawn allowlist");
+        } else {
+            println!("  codehud not in main agent spawn allowlist");
+        }
+
+        write_config(&config)?;
+
+        // 2. Remove workspace (only with --force)
+        let ws = workspace_dir();
+        if ws.exists() {
+            if force {
+                fs::remove_dir_all(&ws)?;
+                println!("✓ Removed workspace at {}", ws.display());
+            } else {
+                println!("  Workspace preserved at {} (use --force to remove)", ws.display());
+            }
+        }
+
+        // 3. Remove state dir
+        let state = state_dir();
+        if state.exists() {
+            fs::remove_dir_all(&state)?;
+            println!("✓ Removed agent state dir");
+        }
+
+        println!();
+        println!("Run 'openclaw gateway restart' to apply changes");
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "OpenClaw"
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+pub mod agent;
 pub mod skill;
 pub(crate) mod parser;
 pub(crate) mod extractor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use codehud::{detect_language, editor, process_path, search, tree, ProcessOptions, OutputFormat, Language, CodehudError};
 use codehud::editor::{BatchEdit, EditResult};
+use codehud::agent;
 use codehud::skill;
 use std::{fs, io::{self, Read}, path::Path, process};
 
@@ -168,6 +169,27 @@ enum Commands {
         platform: String,
     },
 
+    /// Register codehud as a standalone agent on a platform
+    InstallAgent {
+        /// Platform to install for (e.g. openclaw)
+        #[arg(required_unless_present = "list")]
+        platform: Option<String>,
+
+        /// List available platforms
+        #[arg(long)]
+        list: bool,
+    },
+
+    /// Unregister codehud agent from a platform
+    UninstallAgent {
+        /// Platform to uninstall from
+        platform: String,
+
+        /// Also remove workspace directory
+        #[arg(long)]
+        force: bool,
+    },
+
     /// Edit a symbol in a file
     Edit {
         /// File to edit
@@ -239,6 +261,22 @@ fn main() {
         }
         Some(Commands::UninstallSkill { platform }) => {
             if let Err(e) = skill::uninstall(&platform) {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
+        Some(Commands::InstallAgent { platform, list }) => {
+            if list {
+                agent::list_platforms();
+            } else if let Some(p) = platform {
+                if let Err(e) = agent::install(&p) {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Some(Commands::UninstallAgent { platform, force }) => {
+            if let Err(e) = agent::uninstall(&platform, force) {
                 eprintln!("Error: {}", e);
                 process::exit(1);
             }


### PR DESCRIPTION
## Summary

Adds `codehud install-agent <platform>` and `codehud uninstall-agent <platform>` subcommands for registering/removing a standalone Code HUD agent on supported platforms.

### What it does

**`codehud install-agent openclaw`:**
- Creates workspace at `~/.openclaw/workspace-codehud/` with SOUL.md, IDENTITY.md, AGENTS.md
- Installs codehud skill into the agent's workspace
- Registers agent in `~/.openclaw/openclaw.json` (agents.list)
- Adds `codehud` to main agent's spawn allowlist
- Creates agent state directory

**`codehud uninstall-agent openclaw`:**
- Removes agent from openclaw.json
- Removes from spawn allowlist
- Optionally removes workspace (`--force`)
- Removes state directory

### Implementation
- New `src/agent/mod.rs` with `AgentAdapter` trait (mirrors `src/skill/mod.rs` pattern)
- New `src/agent/openclaw.rs` with full OpenClaw implementation
- Config manipulation via `serde_json::Value` to preserve existing structure
- CLI wired via clap subcommands: `install-agent`, `install-agent --list`, `uninstall-agent`, `uninstall-agent --force`

Closes #36