### PR TITLE
refactor: structured error handling with thiserror and tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-javascript",
  "tree-sitter-python",
@@ -357,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,10 +399,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -413,6 +439,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "prettyplease"
@@ -581,10 +613,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "streaming-iterator"
@@ -640,6 +687,76 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -719,6 +836,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ ignore = "0.4"
 regex = "1"
 rayon = "1.10"
 globset = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,50 +1,15 @@
 mod openclaw;
 
-use std::fmt;
+use crate::CodehudError;
 
 /// Trait that each platform adapter implements for agent registration.
 pub trait AgentAdapter {
     /// Install/register the codehud agent for this platform.
-    fn install(&self) -> Result<(), AgentError>;
+    fn install(&self) -> Result<(), CodehudError>;
     /// Uninstall/remove the codehud agent from this platform.
-    fn uninstall(&self, force: bool) -> Result<(), AgentError>;
+    fn uninstall(&self, force: bool) -> Result<(), CodehudError>;
     /// Human-readable platform name.
     fn name(&self) -> &'static str;
-}
-
-#[derive(Debug)]
-pub enum AgentError {
-    NotImplemented(String),
-    Io(std::io::Error),
-    Json(serde_json::Error),
-    UnknownPlatform(String),
-    Config(String),
-}
-
-impl fmt::Display for AgentError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AgentError::NotImplemented(p) => write!(f, "{} agent adapter not yet implemented", p),
-            AgentError::Io(e) => write!(f, "IO error: {}", e),
-            AgentError::Json(e) => write!(f, "JSON error: {}", e),
-            AgentError::UnknownPlatform(p) => {
-                write!(f, "Unknown platform '{}'. Available platforms: {}", p, PLATFORMS.join(", "))
-            }
-            AgentError::Config(msg) => write!(f, "Config error: {}", msg),
-        }
-    }
-}
-
-impl From<std::io::Error> for AgentError {
-    fn from(e: std::io::Error) -> Self {
-        AgentError::Io(e)
-    }
-}
-
-impl From<serde_json::Error> for AgentError {
-    fn from(e: serde_json::Error) -> Self {
-        AgentError::Json(e)
-    }
 }
 
 /// All supported platform names for agent installation.
@@ -59,21 +24,24 @@ pub fn list_platforms() {
 }
 
 /// Get the adapter for a given platform name.
-fn get_adapter(platform: &str) -> Result<Box<dyn AgentAdapter>, AgentError> {
+fn get_adapter(platform: &str) -> Result<Box<dyn AgentAdapter>, CodehudError> {
     match platform {
         "openclaw" => Ok(Box::new(openclaw::OpenClawAdapter)),
-        _ => Err(AgentError::UnknownPlatform(platform.to_string())),
+        _ => Err(CodehudError::UnknownPlatform {
+            platform: platform.to_string(),
+            available: PLATFORMS.join(", "),
+        }),
     }
 }
 
 /// Install agent for the given platform.
-pub fn install(platform: &str) -> Result<(), AgentError> {
+pub fn install(platform: &str) -> Result<(), CodehudError> {
     let adapter = get_adapter(platform)?;
     adapter.install()
 }
 
 /// Uninstall agent for the given platform.
-pub fn uninstall(platform: &str, force: bool) -> Result<(), AgentError> {
+pub fn uninstall(platform: &str, force: bool) -> Result<(), CodehudError> {
     let adapter = get_adapter(platform)?;
     adapter.uninstall(force)
 }

--- a/src/agent/openclaw.rs
+++ b/src/agent/openclaw.rs
@@ -1,7 +1,9 @@
-use super::{AgentAdapter, AgentError};
+use super::AgentAdapter;
+use crate::CodehudError;
 use crate::skill::content::SKILL_CONTENT;
 use std::fs;
 use std::path::PathBuf;
+use tracing::{debug, info, warn};
 
 pub struct OpenClawAdapter;
 
@@ -89,49 +91,52 @@ metadata:
 ---
 "#;
 
-fn home_dir() -> PathBuf {
-    dirs::home_dir().expect("could not determine home directory")
+fn home_dir() -> Result<PathBuf, CodehudError> {
+    dirs::home_dir().ok_or(CodehudError::HomeDir)
 }
 
-fn workspace_dir() -> PathBuf {
-    home_dir().join(".openclaw/workspace-codehud")
+fn workspace_dir() -> Result<PathBuf, CodehudError> {
+    Ok(home_dir()?.join(".openclaw/workspace-codehud"))
 }
 
-fn config_path() -> PathBuf {
-    home_dir().join(".openclaw/openclaw.json")
+fn config_path() -> Result<PathBuf, CodehudError> {
+    Ok(home_dir()?.join(".openclaw/openclaw.json"))
 }
 
-fn state_dir() -> PathBuf {
-    home_dir().join(".openclaw/agents/codehud/agent")
+fn state_dir() -> Result<PathBuf, CodehudError> {
+    Ok(home_dir()?.join(".openclaw/agents/codehud/agent"))
 }
 
 /// Read the openclaw.json config as a serde_json::Value.
-fn read_config() -> Result<serde_json::Value, AgentError> {
-    let path = config_path();
+fn read_config() -> Result<serde_json::Value, CodehudError> {
+    let path = config_path()?;
     if !path.exists() {
-        return Err(AgentError::Config(format!(
+        return Err(CodehudError::Config(format!(
             "Config file not found: {}. Is OpenClaw installed?",
             path.display()
         )));
     }
+    debug!(path = %path.display(), "Reading OpenClaw config");
     let content = fs::read_to_string(&path)?;
     let config: serde_json::Value = serde_json::from_str(&content)?;
     Ok(config)
 }
 
 /// Write the config back to openclaw.json with pretty formatting.
-fn write_config(config: &serde_json::Value) -> Result<(), AgentError> {
+fn write_config(config: &serde_json::Value) -> Result<(), CodehudError> {
+    let path = config_path()?;
     let content = serde_json::to_string_pretty(config)?;
-    fs::write(config_path(), content)?;
+    fs::write(&path, content)?;
+    debug!(path = %path.display(), "Wrote OpenClaw config");
     Ok(())
 }
 
 /// Add the codehud agent entry to agents.list[] if not already present.
-fn add_agent_to_config(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+fn add_agent_to_config(config: &mut serde_json::Value) -> Result<bool, CodehudError> {
     let agents_list = config
         .pointer_mut("/agents/list")
         .and_then(|v| v.as_array_mut())
-        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+        .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     // Check if already present
     for entry in agents_list.iter() {
@@ -160,11 +165,11 @@ fn add_agent_to_config(config: &mut serde_json::Value) -> Result<bool, AgentErro
 }
 
 /// Remove the codehud agent entry from agents.list[].
-fn remove_agent_from_config(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+fn remove_agent_from_config(config: &mut serde_json::Value) -> Result<bool, CodehudError> {
     let agents_list = config
         .pointer_mut("/agents/list")
         .and_then(|v| v.as_array_mut())
-        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+        .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     let before = agents_list.len();
     agents_list.retain(|entry| {
@@ -174,11 +179,11 @@ fn remove_agent_from_config(config: &mut serde_json::Value) -> Result<bool, Agen
 }
 
 /// Add "codehud" to the main agent's subagents.allowAgents array.
-fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, CodehudError> {
     let agents_list = config
         .pointer_mut("/agents/list")
         .and_then(|v| v.as_array_mut())
-        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+        .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     // Find the main/default agent
     for entry in agents_list.iter_mut() {
@@ -187,17 +192,18 @@ fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentE
 
         if is_main {
             // Navigate to subagents.allowAgents, creating if needed
-            let subagents = entry
-                .as_object_mut()
-                .unwrap()
+            let entry_obj = entry.as_object_mut()
+                .ok_or_else(|| CodehudError::Config("agent entry is not an object".to_string()))?;
+            let subagents = entry_obj
                 .entry("subagents")
                 .or_insert_with(|| serde_json::json!({}));
-            let allow = subagents
-                .as_object_mut()
-                .unwrap()
+            let subagents_obj = subagents.as_object_mut()
+                .ok_or_else(|| CodehudError::Config("subagents is not an object".to_string()))?;
+            let allow = subagents_obj
                 .entry("allowAgents")
                 .or_insert_with(|| serde_json::json!([]));
-            let arr = allow.as_array_mut().unwrap();
+            let arr = allow.as_array_mut()
+                .ok_or_else(|| CodehudError::Config("allowAgents is not an array".to_string()))?;
 
             if arr.iter().any(|v| v.as_str() == Some(AGENT_ID)) {
                 return Ok(false); // already present
@@ -206,15 +212,16 @@ fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentE
             return Ok(true);
         }
     }
-    Ok(false) // no main agent found
+    warn!("No main agent found in config — skipping spawn allowlist");
+    Ok(false)
 }
 
 /// Remove "codehud" from the main agent's subagents.allowAgents array.
-fn remove_from_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, AgentError> {
+fn remove_from_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, CodehudError> {
     let agents_list = config
         .pointer_mut("/agents/list")
         .and_then(|v| v.as_array_mut())
-        .ok_or_else(|| AgentError::Config("agents.list not found in config".to_string()))?;
+        .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     for entry in agents_list.iter_mut() {
         let is_main = entry.get("default").and_then(|v| v.as_bool()).unwrap_or(false)
@@ -236,14 +243,15 @@ fn remove_from_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, A
 }
 
 impl AgentAdapter for OpenClawAdapter {
-    fn install(&self) -> Result<(), AgentError> {
-        let ws = workspace_dir();
+    fn install(&self) -> Result<(), CodehudError> {
+        let ws = workspace_dir()?;
 
         // 1. Create workspace and write files
         fs::create_dir_all(&ws)?;
         fs::write(ws.join("SOUL.md"), SOUL_MD.trim())?;
         fs::write(ws.join("IDENTITY.md"), IDENTITY_MD.trim())?;
         fs::write(ws.join("AGENTS.md"), AGENTS_MD.trim())?;
+        info!(workspace = %ws.display(), "Created agent workspace");
         println!("✓ Created workspace at {}", ws.display());
 
         // 2. Install codehud skill into agent workspace
@@ -251,26 +259,32 @@ impl AgentAdapter for OpenClawAdapter {
         fs::create_dir_all(&skill_dir)?;
         let skill_content = format!("{}\n{}\n", SKILL_FRONTMATTER.trim(), SKILL_CONTENT.trim());
         fs::write(skill_dir.join("SKILL.md"), skill_content)?;
+        info!(skill_dir = %skill_dir.display(), "Installed codehud skill");
         println!("✓ Installed codehud skill to {}", skill_dir.display());
 
         // 3. Create agent state directory
-        let state = state_dir();
+        let state = state_dir()?;
         fs::create_dir_all(&state)?;
+        debug!(state_dir = %state.display(), "Created agent state directory");
         println!("✓ Created agent state dir at {}", state.display());
 
         // 4. Register in openclaw.json
         let mut config = read_config()?;
         let added = add_agent_to_config(&mut config)?;
         if added {
+            info!("Registered codehud agent in openclaw.json");
             println!("✓ Registered codehud agent in openclaw.json");
         } else {
+            debug!("codehud agent already registered");
             println!("  codehud agent already registered in openclaw.json");
         }
 
         let allowlisted = add_to_spawn_allowlist(&mut config)?;
         if allowlisted {
+            info!("Added codehud to main agent spawn allowlist");
             println!("✓ Added codehud to main agent spawn allowlist");
         } else {
+            debug!("codehud already in spawn allowlist");
             println!("  codehud already in main agent spawn allowlist");
         }
 
@@ -281,30 +295,35 @@ impl AgentAdapter for OpenClawAdapter {
         Ok(())
     }
 
-    fn uninstall(&self, force: bool) -> Result<(), AgentError> {
+    fn uninstall(&self, force: bool) -> Result<(), CodehudError> {
         // 1. Update openclaw.json
         let mut config = read_config()?;
         let removed = remove_agent_from_config(&mut config)?;
         if removed {
+            info!("Removed codehud agent from openclaw.json");
             println!("✓ Removed codehud agent from openclaw.json");
         } else {
+            debug!("codehud agent not found in config");
             println!("  codehud agent not found in openclaw.json");
         }
 
         let unlisted = remove_from_spawn_allowlist(&mut config)?;
         if unlisted {
+            info!("Removed codehud from spawn allowlist");
             println!("✓ Removed codehud from main agent spawn allowlist");
         } else {
+            debug!("codehud not in spawn allowlist");
             println!("  codehud not in main agent spawn allowlist");
         }
 
         write_config(&config)?;
 
         // 2. Remove workspace (only with --force)
-        let ws = workspace_dir();
+        let ws = workspace_dir()?;
         if ws.exists() {
             if force {
                 fs::remove_dir_all(&ws)?;
+                info!(workspace = %ws.display(), "Removed agent workspace");
                 println!("✓ Removed workspace at {}", ws.display());
             } else {
                 println!("  Workspace preserved at {} (use --force to remove)", ws.display());
@@ -312,9 +331,10 @@ impl AgentAdapter for OpenClawAdapter {
         }
 
         // 3. Remove state dir
-        let state = state_dir();
+        let state = state_dir()?;
         if state.exists() {
             fs::remove_dir_all(&state)?;
+            debug!(state_dir = %state.display(), "Removed agent state directory");
             println!("✓ Removed agent state dir");
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,4 +32,25 @@ pub enum CodehudError {
         symbols: String,
         path: String,
     },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Git error: {0}")]
+    Git(String),
+
+    #[error("Config error: {0}")]
+    Config(String),
+
+    #[error("Could not determine home directory")]
+    HomeDir,
+
+    #[error("Unknown platform '{platform}'. Available platforms: {available}")]
+    UnknownPlatform {
+        platform: String,
+        available: String,
+    },
+
+    #[error("{0} adapter not yet implemented")]
+    NotImplemented(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use codehud::editor::{BatchEdit, EditResult};
 use codehud::agent;
 use codehud::skill;
 use std::{fs, io::{self, Read}, path::Path, process};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(name = "codehud")]
@@ -246,6 +247,11 @@ enum Commands {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
     
     match cli.command {
@@ -782,9 +788,9 @@ fn handle_edit(
     
     if json {
         if edit_results.len() == 1 {
-            println!("{}", serde_json::to_string(&edit_results[0]).unwrap());
+            println!("{}", serde_json::to_string(&edit_results[0])?);
         } else {
-            println!("{}", serde_json::to_string(&edit_results).unwrap());
+            println!("{}", serde_json::to_string(&edit_results)?);
         }
     }
     

--- a/src/skill/aider.rs
+++ b/src/skill/aider.rs
@@ -1,14 +1,15 @@
-use super::{PlatformAdapter, SkillError};
+use super::PlatformAdapter;
+use crate::CodehudError;
 
 pub struct AiderAdapter;
 
 impl PlatformAdapter for AiderAdapter {
-    fn install(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Aider".to_string()))
+    fn install(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Aider".to_string()))
     }
 
-    fn uninstall(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Aider".to_string()))
+    fn uninstall(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Aider".to_string()))
     }
 
     fn name(&self) -> &'static str {

--- a/src/skill/claude_code.rs
+++ b/src/skill/claude_code.rs
@@ -1,14 +1,15 @@
-use super::{PlatformAdapter, SkillError};
+use super::PlatformAdapter;
+use crate::CodehudError;
 
 pub struct ClaudeCodeAdapter;
 
 impl PlatformAdapter for ClaudeCodeAdapter {
-    fn install(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Claude Code".to_string()))
+    fn install(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Claude Code".to_string()))
     }
 
-    fn uninstall(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Claude Code".to_string()))
+    fn uninstall(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Claude Code".to_string()))
     }
 
     fn name(&self) -> &'static str {

--- a/src/skill/codex.rs
+++ b/src/skill/codex.rs
@@ -1,14 +1,15 @@
-use super::{PlatformAdapter, SkillError};
+use super::PlatformAdapter;
+use crate::CodehudError;
 
 pub struct CodexAdapter;
 
 impl PlatformAdapter for CodexAdapter {
-    fn install(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Codex".to_string()))
+    fn install(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Codex".to_string()))
     }
 
-    fn uninstall(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Codex".to_string()))
+    fn uninstall(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Codex".to_string()))
     }
 
     fn name(&self) -> &'static str {

--- a/src/skill/cursor.rs
+++ b/src/skill/cursor.rs
@@ -1,14 +1,15 @@
-use super::{PlatformAdapter, SkillError};
+use super::PlatformAdapter;
+use crate::CodehudError;
 
 pub struct CursorAdapter;
 
 impl PlatformAdapter for CursorAdapter {
-    fn install(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Cursor".to_string()))
+    fn install(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Cursor".to_string()))
     }
 
-    fn uninstall(&self) -> Result<(), SkillError> {
-        Err(SkillError::NotImplemented("Cursor".to_string()))
+    fn uninstall(&self) -> Result<(), CodehudError> {
+        Err(CodehudError::NotImplemented("Cursor".to_string()))
     }
 
     fn name(&self) -> &'static str {

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -5,41 +5,16 @@ mod codex;
 mod cursor;
 mod aider;
 
-use std::fmt;
+use crate::CodehudError;
 
 /// Trait that each platform adapter implements.
 pub trait PlatformAdapter {
     /// Install the codehud skill for this platform.
-    fn install(&self) -> Result<(), SkillError>;
+    fn install(&self) -> Result<(), CodehudError>;
     /// Uninstall the codehud skill for this platform.
-    fn uninstall(&self) -> Result<(), SkillError>;
+    fn uninstall(&self) -> Result<(), CodehudError>;
     /// Human-readable platform name.
     fn name(&self) -> &'static str;
-}
-
-#[derive(Debug)]
-pub enum SkillError {
-    NotImplemented(String),
-    Io(std::io::Error),
-    UnknownPlatform(String),
-}
-
-impl fmt::Display for SkillError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SkillError::NotImplemented(p) => write!(f, "{} adapter not yet implemented (see https://github.com/AvoCloud/codeview/issues)", p),
-            SkillError::Io(e) => write!(f, "IO error: {}", e),
-            SkillError::UnknownPlatform(p) => {
-                write!(f, "Unknown platform '{}'. Available platforms: {}", p, PLATFORMS.join(", "))
-            }
-        }
-    }
-}
-
-impl From<std::io::Error> for SkillError {
-    fn from(e: std::io::Error) -> Self {
-        SkillError::Io(e)
-    }
 }
 
 /// All supported platform names.
@@ -54,25 +29,28 @@ pub fn list_platforms() {
 }
 
 /// Get the adapter for a given platform name.
-fn get_adapter(platform: &str) -> Result<Box<dyn PlatformAdapter>, SkillError> {
+fn get_adapter(platform: &str) -> Result<Box<dyn PlatformAdapter>, CodehudError> {
     match platform {
         "openclaw" => Ok(Box::new(openclaw::OpenClawAdapter)),
         "claude-code" => Ok(Box::new(claude_code::ClaudeCodeAdapter)),
         "codex" => Ok(Box::new(codex::CodexAdapter)),
         "cursor" => Ok(Box::new(cursor::CursorAdapter)),
         "aider" => Ok(Box::new(aider::AiderAdapter)),
-        _ => Err(SkillError::UnknownPlatform(platform.to_string())),
+        _ => Err(CodehudError::UnknownPlatform {
+            platform: platform.to_string(),
+            available: PLATFORMS.join(", "),
+        }),
     }
 }
 
 /// Install skill for the given platform.
-pub fn install(platform: &str) -> Result<(), SkillError> {
+pub fn install(platform: &str) -> Result<(), CodehudError> {
     let adapter = get_adapter(platform)?;
     adapter.install()
 }
 
 /// Uninstall skill for the given platform.
-pub fn uninstall(platform: &str) -> Result<(), SkillError> {
+pub fn uninstall(platform: &str) -> Result<(), CodehudError> {
     let adapter = get_adapter(platform)?;
     adapter.uninstall()
 }

--- a/src/skill/openclaw.rs
+++ b/src/skill/openclaw.rs
@@ -1,7 +1,9 @@
-use super::{PlatformAdapter, SkillError};
+use super::PlatformAdapter;
 use super::content::SKILL_CONTENT;
+use crate::CodehudError;
 use std::fs;
 use std::path::PathBuf;
+use tracing::{debug, info};
 
 pub struct OpenClawAdapter;
 
@@ -27,36 +29,37 @@ metadata:
 ---
 "#;
 
-fn skill_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("could not determine home directory")
-        .join(".openclaw/workspace/skills/codehud")
+fn skill_dir() -> Result<PathBuf, CodehudError> {
+    Ok(dirs::home_dir()
+        .ok_or(CodehudError::HomeDir)?
+        .join(".openclaw/workspace/skills/codehud"))
 }
 
 impl PlatformAdapter for OpenClawAdapter {
-    fn install(&self) -> Result<(), SkillError> {
-        let dir = skill_dir();
+    fn install(&self) -> Result<(), CodehudError> {
+        let dir = skill_dir()?;
         fs::create_dir_all(&dir)?;
         let path = dir.join("SKILL.md");
         let content = format!("{}\n{}\n", FRONTMATTER.trim(), SKILL_CONTENT.trim());
         fs::write(&path, content)?;
+        info!(path = %path.display(), "Installed codehud skill");
         println!("Installed codehud skill to {}", path.display());
         Ok(())
     }
 
-    fn uninstall(&self) -> Result<(), SkillError> {
-        let dir = skill_dir();
+    fn uninstall(&self) -> Result<(), CodehudError> {
+        let dir = skill_dir()?;
         let path = dir.join("SKILL.md");
         if path.exists() {
             fs::remove_file(&path)?;
+            info!(path = %path.display(), "Removed codehud skill");
             println!("Removed {}", path.display());
         }
         // Remove directory if empty
-        if dir.exists() {
-            if fs::read_dir(&dir)?.next().is_none() {
-                fs::remove_dir(&dir)?;
-                println!("Removed empty directory {}", dir.display());
-            }
+        if dir.exists() && fs::read_dir(&dir)?.next().is_none() {
+            fs::remove_dir(&dir)?;
+            debug!(dir = %dir.display(), "Removed empty skill directory");
+            println!("Removed empty directory {}", dir.display());
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Replaces ad-hoc error types (`SkillError`, `AgentError`) with a unified `CodehudError` enum using `thiserror`, and adds `tracing` instrumentation to key operations.

### Changes

- **Unified error type** — merged `SkillError` and `AgentError` into `CodehudError` with new variants: `Io`, `Git`, `Config`, `HomeDir`, `UnknownPlatform`, `NotImplemented`
- **Eliminated panicking unwraps** — replaced `as_object_mut().unwrap()`, `as_array_mut().unwrap()` in config manipulation (agent/openclaw.rs) with proper `?` propagation and descriptive errors
- **Replaced `expect()` calls** — `dirs::home_dir().expect()` now returns `CodehudError::HomeDir`
- **Added tracing** — `tracing` + `tracing-subscriber` with env-filter; `info!`/`debug!`/`warn!` in agent and skill install/uninstall paths
- **Fixed JSON output** — `serde_json::to_string().unwrap()` in edit command replaced with `?`

### Testing

All 517 tests pass. No new clippy warnings.