### PR TITLE
fix: handle SIGPIPE gracefully (fixes #39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "dirs",
  "globset",
  "ignore",
+ "libc",
  "rayon",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rayon = "1.10"
 globset = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+libc = "0.2.182"
 
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,12 @@ enum Commands {
 }
 
 fn main() {
+    // Reset SIGPIPE to default behavior so piping to head/less doesn't panic (#39)
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .with_writer(std::io::stderr)


### PR DESCRIPTION
Resets SIGPIPE to default behavior at program start so piping output to `head`/`less` no longer causes a broken pipe panic.

Adds `libc` dependency and calls `libc::signal(libc::SIGPIPE, libc::SIG_DFL)` before any I/O.

Fixes #39