### PR TITLE
fix: resolve absolute paths in --diff mode

### DIFF
--- a/src/diff_cli.rs
+++ b/src/diff_cli.rs
@@ -33,7 +33,17 @@ pub struct DiffOptions {
 pub fn run_diff(opts: &DiffOptions) -> Result<String, CodehudError> {
     // Determine the repo root from the path scope or cwd
     let start = match &opts.path_scope {
-        Some(p) => std::path::PathBuf::from(p),
+        Some(p) => {
+            let pb = std::path::PathBuf::from(p);
+            // git -C requires a directory; if the path is a file, use its parent
+            if pb.is_file() {
+                pb.parent()
+                    .map(|d| d.to_path_buf())
+                    .unwrap_or(pb)
+            } else {
+                pb
+            }
+        }
         None => std::env::current_dir()
             .map_err(|e| CodehudError::ParseError(format!("cannot get cwd: {e}")))?,
     };


### PR DESCRIPTION
When `--diff` is invoked with an absolute file path (e.g. `codehud /mnt/data/n8n/packages/cli/src/server.ts --diff`), the path was passed directly to `git -C`, which requires a directory. This caused a "Not a directory" error.

**Fix:** When the path scope points to a file rather than a directory, use its parent directory for git repo discovery.

Fixes #40