### PR TITLE
feat: machine-readable output format (refs #41)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub fn process_path(
 ///
 /// `lines_arg` should be in the format "N-M" (1-indexed, inclusive).
 /// Returns formatted output with an enclosing-symbol context header and line numbers.
-pub fn extract_lines(path_str: &str, lines_arg: &str) -> Result<String, CodehudError> {
+pub fn extract_lines(path_str: &str, lines_arg: &str, json: bool) -> Result<String, CodehudError> {
     use std::fmt::Write;
 
     let path = Path::new(path_str);
@@ -128,16 +128,48 @@ pub fn extract_lines(path_str: &str, lines_arg: &str) -> Result<String, CodehudE
     }
     let end = end.min(total_lines);
 
-    let mut output = String::new();
+    let mut symbol_path = Vec::new();
 
     // Only attempt structural context for supported languages
     if languages::is_supported_file(path) {
         let language = languages::detect_language(path)?;
         let tree = parser::parse(&source, language)?;
-        let symbols = search::find_enclosing_symbols(&tree, &source, start - 1, language);
-        if !symbols.is_empty() {
-            writeln!(output, "// Inside: {}", symbols.join(" > ")).unwrap();
+        symbol_path = search::find_enclosing_symbols(&tree, &source, start - 1, language);
+    }
+
+    if json {
+        #[derive(serde::Serialize)]
+        struct LinesOutput {
+            file: String,
+            start: usize,
+            end: usize,
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            symbol_path: Vec<String>,
+            lines: Vec<LineEntry>,
         }
+        #[derive(serde::Serialize)]
+        struct LineEntry {
+            line: usize,
+            content: String,
+        }
+        let lines_vec: Vec<&str> = source.lines().collect();
+        let entries: Vec<LineEntry> = lines_vec.iter().enumerate()
+            .take(end).skip(start - 1)
+            .map(|(i, line)| LineEntry { line: i + 1, content: line.to_string() })
+            .collect();
+        let output = LinesOutput {
+            file: path_str.to_string(),
+            start,
+            end,
+            symbol_path,
+            lines: entries,
+        };
+        return Ok(serde_json::to_string(&output).map_err(|e| CodehudError::ParseError(e.to_string()))?);
+    }
+
+    let mut output = String::new();
+    if !symbol_path.is_empty() {
+        writeln!(output, "// Inside: {}", symbol_path.join(" > ")).unwrap();
     }
 
     // Extract and format lines

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn main() {
 
             // Handle --lines mode
             if let Some(lines_arg) = cli.lines {
-                match codehud::extract_lines(&path, &lines_arg) {
+                match codehud::extract_lines(&path, &lines_arg, cli.json) {
                     Ok(output) => {
                         print!("{}", output);
                     }
@@ -463,6 +463,7 @@ fn main() {
                     max_results: cli.max_results.or(if is_dir { Some(20) } else { None }),
                     no_tests: cli.no_tests,
                     exclude: cli.exclude,
+                    json: cli.json,
                 };
                 match search::search_path(&path, &search_opts) {
                     Ok(output) if output.is_empty() => {

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,6 +4,7 @@ use crate::languages::{self, Language};
 use crate::parser;
 use crate::walk;
 use regex::{Regex, RegexBuilder};
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::fs;
@@ -28,6 +29,7 @@ pub struct SearchOptions {
     pub max_results: Option<usize>,
     pub no_tests: bool,
     pub exclude: Vec<String>,
+    pub json: bool,
 }
 
 /// Perform structural search on a path (file or directory).
@@ -112,13 +114,20 @@ pub fn search_path(
             let shown_files = capped_results.len();
             let extra_files = total_files_with_matches - shown_files;
 
+            if options.json {
+                return Ok(format_search_json(&capped_results));
+            }
             let mut output = format_search_results(&capped_results);
             writeln!(output, "\n... and {} more matches across {} files", overflow, extra_files).unwrap();
             return Ok(output);
         }
     }
 
-    Ok(format_search_results(&file_results))
+    if options.json {
+        Ok(format_search_json(&file_results))
+    } else {
+        Ok(format_search_results(&file_results))
+    }
 }
 
 /// Search a single file and return matches with structural context.
@@ -324,6 +333,31 @@ fn find_symbols_at_line(
 }
 
 /// Format search results grouped by file and enclosing symbol.
+fn format_search_json(file_results: &[(String, Vec<SearchMatch>)]) -> String {
+    #[derive(Serialize)]
+    struct JsonMatch {
+        file: String,
+        line: usize,
+        content: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        symbol_path: Vec<String>,
+    }
+
+    let mut lines = Vec::new();
+    for (file_path, matches) in file_results {
+        for m in matches {
+            let entry = JsonMatch {
+                file: file_path.clone(),
+                line: m.line_number,
+                content: m.line_content.clone(),
+                symbol_path: m.symbol_path.clone(),
+            };
+            lines.push(serde_json::to_string(&entry).unwrap());
+        }
+    }
+    lines.join("\n")
+}
+
 fn format_search_results(file_results: &[(String, Vec<SearchMatch>)]) -> String {
     let mut output = String::new();
 
@@ -400,6 +434,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("hello"));
@@ -425,6 +460,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(!result.contains("Message"));
@@ -439,6 +475,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("Message"));
@@ -462,6 +499,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("L2:"));
@@ -484,6 +522,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         assert!(result.contains("a.rs"));
@@ -503,6 +542,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.is_empty());
@@ -521,6 +561,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("(top-level)"));
@@ -548,6 +589,7 @@ fn goodbye() {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("MyClass"));
@@ -575,6 +617,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("impl Foo"));
@@ -597,6 +640,7 @@ impl Foo {
             max_results: Some(3),
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         // Should contain the summary line
@@ -616,6 +660,7 @@ impl Foo {
             max_results: Some(10),
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(!result.contains("... and"));
@@ -639,6 +684,7 @@ impl Foo {
             max_results: None, // single-file default: no cap
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(!result.contains("... and"));
@@ -666,6 +712,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("L2:"), "should match TODO line");
@@ -693,6 +740,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("L2:"), "should match TODO line with \\| syntax");
@@ -717,6 +765,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("L2:"), "case-insensitive should match todo");
@@ -744,6 +793,7 @@ impl Foo {
             max_results: None,
             no_tests: true,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&dir_str, &opts).unwrap();
         assert!(result.contains("main.rs"), "non-test file should appear in search results");
@@ -775,6 +825,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("config.yml"));
@@ -797,6 +848,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("settings.json"));
@@ -816,6 +868,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("README.md"));
@@ -835,6 +888,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("sample.env"));
@@ -857,6 +911,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         assert!(result.contains("main.rs"), "should find match in code file");
@@ -879,6 +934,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         assert!(result.contains("config.yml"));
@@ -898,6 +954,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.is_empty());
@@ -916,6 +973,7 @@ impl Foo {
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("Cargo.toml"));

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -108,6 +108,7 @@ fn exclude_with_search() {
         max_results: None,
         no_tests: false,
         exclude: vec!["dist".to_string()],
+        json: false,
     };
     let output = codehud::search::search_path(dir.path().to_str().unwrap(), &search_opts).unwrap();
     assert!(output.contains("main.rs"), "should find main in src/main.rs");

--- a/tests/lines_test.rs
+++ b/tests/lines_test.rs
@@ -11,7 +11,7 @@ fn write_file(dir: &TempDir, name: &str, content: &str) -> String {
 fn lines_basic_extraction() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {\n    let x = 1;\n    let y = 2;\n    x + y\n}\n");
-    let result = codehud::extract_lines(&path, "2-4").unwrap();
+    let result = codehud::extract_lines(&path, "2-4", false).unwrap();
     assert!(result.contains("// Inside: foo"));
     assert!(result.contains("L2:"));
     assert!(result.contains("L3:"));
@@ -25,7 +25,7 @@ fn lines_basic_extraction() {
 fn lines_single_line() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {\n    42\n}\n");
-    let result = codehud::extract_lines(&path, "2-2").unwrap();
+    let result = codehud::extract_lines(&path, "2-2", false).unwrap();
     assert!(result.contains("L2:"));
     assert!(result.contains("42"));
 }
@@ -34,7 +34,7 @@ fn lines_single_line() {
 fn lines_top_level_no_context() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "use std::io;\n\nfn foo() {}\n");
-    let result = codehud::extract_lines(&path, "1-1").unwrap();
+    let result = codehud::extract_lines(&path, "1-1", false).unwrap();
     // use statement is a top-level item, not inside anything — but it may still show context
     assert!(result.contains("L1:"));
     assert!(result.contains("use std::io;"));
@@ -44,7 +44,7 @@ fn lines_top_level_no_context() {
 fn lines_out_of_range_start() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {}\n");
-    let result = codehud::extract_lines(&path, "100-200");
+    let result = codehud::extract_lines(&path, "100-200", false);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("beyond end of file"));
 }
@@ -54,7 +54,7 @@ fn lines_end_beyond_file_clamps() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {\n    42\n}\n");
     // End beyond file should be clamped
-    let result = codehud::extract_lines(&path, "2-999").unwrap();
+    let result = codehud::extract_lines(&path, "2-999", false).unwrap();
     assert!(result.contains("L2:"));
     assert!(result.contains("L3:"));
 }
@@ -63,7 +63,7 @@ fn lines_end_beyond_file_clamps() {
 fn lines_inverted_range_errors() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {}\n");
-    let result = codehud::extract_lines(&path, "5-3");
+    let result = codehud::extract_lines(&path, "5-3", false);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Inverted range"));
 }
@@ -71,7 +71,7 @@ fn lines_inverted_range_errors() {
 #[test]
 fn lines_directory_errors() {
     let dir = TempDir::new().unwrap();
-    let result = codehud::extract_lines(&dir.path().to_string_lossy(), "1-5");
+    let result = codehud::extract_lines(&dir.path().to_string_lossy(), "1-5", false);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("not directories"));
 }
@@ -80,7 +80,7 @@ fn lines_directory_errors() {
 fn lines_nested_context_typescript() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.ts", "class MyClass {\n    run() {\n        console.log('hello');\n    }\n}\n");
-    let result = codehud::extract_lines(&path, "3-3").unwrap();
+    let result = codehud::extract_lines(&path, "3-3", false).unwrap();
     assert!(result.contains("// Inside:"));
     assert!(result.contains("MyClass"));
     assert!(result.contains("run()"));
@@ -91,7 +91,7 @@ fn lines_nested_context_typescript() {
 fn lines_invalid_format() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {}\n");
-    let result = codehud::extract_lines(&path, "abc");
+    let result = codehud::extract_lines(&path, "abc", false);
     assert!(result.is_err());
 }
 
@@ -99,7 +99,7 @@ fn lines_invalid_format() {
 fn lines_zero_start_errors() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn foo() {}\n");
-    let result = codehud::extract_lines(&path, "0-5");
+    let result = codehud::extract_lines(&path, "0-5", false);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("1-indexed"));
 }

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -59,7 +59,7 @@ fn passthrough_view_env() {
 
 #[test]
 fn passthrough_lines_range() {
-    let result = extract_lines(TOML_FIXTURE, "2-4").unwrap();
+    let result = extract_lines(TOML_FIXTURE, "2-4", false).unwrap();
     assert!(result.contains("name = \"example\""));
     assert!(result.contains("version = \"1.0.0\""));
     // Should not contain line 1

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -292,6 +292,7 @@ function increment() { count.value++ }
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         },
     ).unwrap();
     assert!(out.contains("increment"), "Should find increment in Vue file: {out}");
@@ -318,6 +319,7 @@ function increment() { count++ }
             max_results: None,
             no_tests: false,
             exclude: vec![],
+            json: false,
         },
     ).unwrap();
     assert!(out.contains("increment"), "Should find increment in Svelte: {out}");


### PR DESCRIPTION
## Summary

Adds `--json` support to the two features that were missing it: `--search` and `--lines`. All codehud features now consistently support `--json` output.

## Changes

### `--search --json` → NDJSON (newline-delimited JSON)
Each match is one JSON object per line for streaming compatibility:
```json
{"file":"src/main.rs","line":13,"content":"struct Cli {","symbol_path":["Cli"]}
{"file":"src/main.rs","line":255,"content":"    let cli = Cli::parse();","symbol_path":["main()"]}
```

### `--lines --json` → Single JSON object
```json
{"file":"src/main.rs","start":1,"end":3,"symbol_path":[],"lines":[{"line":1,"content":"use clap::..."}]}
```

### Full `--json` coverage
All features now work with `--json`: tree, files, symbols, list-symbols, search, references, xrefs, stats, outline, diff, lines.

Refs #41