### PR TITLE
feat: add summary mode for --stats, reduce verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,17 +234,32 @@ In expand mode, directory traversal stops early once all requested symbols have 
 
 ### Stats mode
 
-Show metadata instead of content — useful for context budgeting:
+Show a summary instead of content — useful for context budgeting:
 
 ```sh
 $ codehud src/ --stats
 ```
 
 ```
-files: 16  lines: 1785  bytes: 56493  items: 111
-  const: 2  enum: 5  function: 27  impl: 4  mod: 20  struct: 8  trait: 1  use: 44
+Files: 12,453 | Dirs: 2,340 | Lines: 185.4k | Bytes: 5.6M | Tokens: ~1.4M
+  Languages: TypeScript (8.2k), JavaScript (2.1k), Rust (1.5k), Python (705)
+  Top dirs: src/components (1,230), src/utils (890), src/api (456)
 
-  src/lib.rs — 166 lines, 5935 bytes, 14 items (2 function, 6 mod, 1 struct, 5 use)
+[Use --stats-detailed for full file list]
+```
+
+For the full per-file breakdown (previous default behavior), use `--stats-detailed`:
+
+```sh
+$ codehud src/ --stats-detailed
+```
+
+```
+Files: 16 | Dirs: 4 | Lines: 1,785 | Bytes: 56,493 | Tokens: ~14,123
+  Languages: Rust (16)
+
+  src/lib.rs — 166 lines, 5935 bytes [Rust]
+  src/main.rs — 245 lines, 8012 bytes [Rust]
   ...
 ```
 
@@ -355,7 +370,8 @@ api.js
 | `--lines N-M` | Extract line range with structural context (1-indexed, inclusive) |
 | `--list-symbols` | Lightweight symbol listing (name, kind, line number) |
 | `--json`     | JSON output                                  |
-| `--stats`    | Show file/item counts instead of content     |
+| `--stats`    | Show summary (files, dirs, languages)         |
+| `--stats-detailed` | Show full per-file breakdown             |
 
 Filters compose: `--pub --fns` shows only public functions.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub struct ProcessOptions {
     pub depth: Option<usize>,
     pub format: OutputFormat,
     pub stats: bool,
-    pub summary_only: bool,
+    pub stats_detailed: bool,
     pub ext: Vec<String>,
     pub signatures: bool,
     pub max_lines: Option<usize>,
@@ -66,7 +66,7 @@ pub fn process_path(
     // Fast path: stats mode doesn't need AST parsing
     if options.stats {
         let fast_stats = pipeline::collect_stats_fast(path, &options)?;
-        return pipeline::format_stats_fast(&fast_stats, options.format, options.summary_only);
+        return pipeline::format_stats_fast(&fast_stats, options.format, !options.stats_detailed);
     }
 
     // Stage 1+2: Collect files and extract items

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,13 +58,13 @@ struct Cli {
     #[arg(long, requires = "list_symbols")]
     imports: bool,
     
-    /// Show stats (file count, lines, bytes, tokens, items) instead of content
+    /// Show stats summary (file count, lines, bytes, top dirs, languages)
     #[arg(long)]
     stats: bool,
 
-    /// Only show aggregate summary in stats mode (skip per-file breakdown)
-    #[arg(long = "summary-only")]
-    summary_only: bool,
+    /// Show full per-file stats (verbose; use for detailed breakdown)
+    #[arg(long = "stats-detailed")]
+    stats_detailed: bool,
 
     /// Filter by file extensions (comma-separated, e.g. --ext rs,ts)
     #[arg(long, value_delimiter = ',')]
@@ -546,10 +546,8 @@ fn main() {
                 cli.depth
             };
 
-            if cli.summary_only && !cli.stats {
-                eprintln!("Error: --summary-only requires --stats");
-                process::exit(1);
-            }
+            // --stats-detailed implies --stats
+            let stats = cli.stats || cli.stats_detailed;
 
             let options = ProcessOptions {
                 symbols: cli.symbols,
@@ -559,8 +557,8 @@ fn main() {
                 no_tests: cli.no_tests,
                 depth: effective_depth,
                 format,
-                stats: cli.stats,
-                summary_only: cli.summary_only,
+                stats,
+                stats_detailed: cli.stats_detailed,
                 ext: cli.ext,
                 signatures: cli.signatures,
                 max_lines: cli.max_lines,

--- a/src/output/stats.rs
+++ b/src/output/stats.rs
@@ -79,7 +79,7 @@ fn format_plain(
     let mut out = String::new();
     let file_count = file_stats.iter().filter(|f| f.items > 0 || file_stats.len() == 1).count();
 
-    writeln!(out, "files: {}  lines: {}  bytes: {}  items: {}",
+    writeln!(out, "Files: {}  Lines: {}  Bytes: {}  Items: {}",
         file_count, total_lines, total_bytes, total_items).unwrap();
 
     if !total_kinds.is_empty() {
@@ -103,6 +103,8 @@ fn format_plain(
             writeln!(out, "  {} — {} lines, {} bytes, {} items ({})",
                 f.path, f.lines, f.bytes, f.items, kinds_str.join(", ")).unwrap();
         }
+    } else if file_stats.len() > 1000 && summary_only {
+        writeln!(out, "\n[Use --stats-detailed for full file list]").unwrap();
     }
 
     Ok(out)

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -189,6 +189,25 @@ fn language_label(path: &Path) -> String {
     }
 }
 
+/// Format a number with comma separators or abbreviated (e.g. 8.2k).
+fn format_count(n: usize) -> String {
+    if n >= 10_000 {
+        let k = n as f64 / 1000.0;
+        format!("{:.1}k", k)
+    } else if n >= 1_000 {
+        // Use comma formatting
+        let s = n.to_string();
+        let mut result = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 { result.push(','); }
+            result.push(c);
+        }
+        result.chars().rev().collect()
+    } else {
+        n.to_string()
+    }
+}
+
 /// Format fast stats output (no items/kinds, shows language breakdown instead).
 pub(crate) fn format_stats_fast(
     file_stats: &[FastFileStats],
@@ -209,22 +228,53 @@ pub(crate) fn format_stats_fast(
         *lang_lines.entry(f.language.clone()).or_default() += f.lines;
     }
 
+    // Compute directory counts and top directories
+    let mut dir_set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut dir_file_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for f in file_stats {
+        if let Some(parent) = std::path::Path::new(&f.path).parent() {
+            let dir = parent.to_string_lossy().to_string();
+            dir_set.insert(dir.clone());
+            *dir_file_counts.entry(dir).or_default() += 1;
+        }
+    }
+    let total_dirs = dir_set.len();
+
+    // Top directories by file count
+    let mut top_dirs: Vec<(String, usize)> = dir_file_counts.into_iter().collect();
+    top_dirs.sort_by(|a, b| b.1.cmp(&a.1));
+    top_dirs.truncate(5);
+
+    let is_large = total_files > 1000;
+
     match format {
         OutputFormat::Plain => {
             let mut out = String::new();
-            writeln!(out, "files: {}  lines: {}  bytes: {}  tokens: ~{}", total_files, total_lines, total_bytes, total_tokens).unwrap();
+            writeln!(out, "Files: {} | Dirs: {} | Lines: {} | Bytes: {} | Tokens: ~{}",
+                format_count(total_files), format_count(total_dirs),
+                format_count(total_lines), format_count(total_bytes),
+                format_count(total_tokens)).unwrap();
             if !lang_counts.is_empty() {
-                let langs: Vec<String> = lang_counts
-                    .iter()
-                    .map(|(k, v)| format!("{}: {} files, {} lines", k, v, lang_lines[k]))
+                let mut langs: Vec<(&String, &usize)> = lang_counts.iter().collect();
+                langs.sort_by(|a, b| b.1.cmp(a.1));
+                let lang_strs: Vec<String> = langs.iter()
+                    .map(|(k, v)| format!("{} ({})", k, format_count(**v)))
                     .collect();
-                writeln!(out, "  {}", langs.join("  ")).unwrap();
+                writeln!(out, "  Languages: {}", lang_strs.join(", ")).unwrap();
+            }
+            if !top_dirs.is_empty() && total_dirs > 1 {
+                let dir_strs: Vec<String> = top_dirs.iter()
+                    .map(|(d, c)| format!("{} ({})", d, c))
+                    .collect();
+                writeln!(out, "  Top dirs: {}", dir_strs.join(", ")).unwrap();
             }
             if !summary_only && file_stats.len() > 1 {
                 writeln!(out).unwrap();
                 for f in file_stats {
                     writeln!(out, "  {} — {} lines, {} bytes [{}]", f.path, f.lines, f.bytes, f.language).unwrap();
                 }
+            } else if file_stats.len() > 1 && is_large {
+                writeln!(out, "\n[Use --stats-detailed for full file list]").unwrap();
             }
             Ok(out)
         }
@@ -330,7 +380,7 @@ pub(crate) fn format_output(
     let expand_mode = !options.symbols.is_empty();
 
     if options.stats {
-        output::stats::format_output(filtered, source_sizes, options.format, options.summary_only)
+        output::stats::format_output(filtered, source_sizes, options.format, !options.stats_detailed)
     } else if options.outline {
         match options.format {
             OutputFormat::Json => output::json::format_output(filtered),
@@ -380,7 +430,7 @@ mod tests {
             depth: None,
             format: OutputFormat::Plain,
             stats: false,
-            summary_only: false,
+            stats_detailed: true,
             ext: vec![],
             signatures: false,
             max_lines: None,

--- a/tests/compact_test.rs
+++ b/tests/compact_test.rs
@@ -10,7 +10,7 @@ fn outline_options(compact: bool) -> ProcessOptions {
         depth: None,
         format: OutputFormat::Plain,
         stats: false,
-        summary_only: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,

--- a/tests/display_names_test.rs
+++ b/tests/display_names_test.rs
@@ -9,7 +9,7 @@ fn list_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -10,7 +10,7 @@ fn default_options() -> ProcessOptions {
         depth: None,
         format: OutputFormat::Plain,
         stats: false,
-        summary_only: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,7 +11,7 @@ fn test_interface_mode_basic() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -47,7 +47,7 @@ fn test_expand_mode() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -80,7 +80,7 @@ fn test_expand_function() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -111,7 +111,7 @@ fn test_pub_filter() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -145,7 +145,7 @@ fn test_fns_filter() {
         fns_only: true,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -180,7 +180,7 @@ fn test_types_filter() {
         fns_only: false,
         types_only: true, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -216,7 +216,7 @@ fn test_combined_pub_fns() {
         fns_only: true,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -254,7 +254,7 @@ fn test_json_output() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Json, stats: false, summary_only: false,
+        format: OutputFormat::Json, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -293,7 +293,7 @@ fn test_nonexistent_path() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -321,7 +321,7 @@ fn test_directory_mode() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: Some(1),
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -352,7 +352,7 @@ fn test_expand_nonexistent_symbol() {
         fns_only: false,
         types_only: false, no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, summary_only: false,
+        format: OutputFormat::Plain, stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -385,7 +385,7 @@ fn test_no_tests_filter() {
         no_tests: true,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -423,7 +423,7 @@ fn test_no_tests_filter_disabled() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -455,7 +455,7 @@ fn test_stats_output_plain() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: true, summary_only: false,
+        stats: true, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -474,7 +474,7 @@ fn test_stats_output_plain() {
     let output = result.unwrap();
 
     // Stats output should contain file count, line/byte info, and token estimate
-    assert!(output.contains("files:") && output.contains("lines:") && output.contains("bytes:") && output.contains("tokens:"),
+    assert!(output.contains("Files:") && output.contains("Lines:") && output.contains("Bytes:") && output.contains("Tokens:"),
             "Stats should contain summary counts including tokens. Got: {}", output);
 }
 
@@ -488,7 +488,7 @@ fn test_stats_output_json() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Json,
-        stats: true, summary_only: false,
+        stats: true, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -525,7 +525,7 @@ fn test_stats_with_directory() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: true, summary_only: false,
+        stats: true, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -558,7 +558,7 @@ fn test_stats_summary_only_plain() {
         depth: None,
         format: OutputFormat::Plain,
         stats: true,
-        summary_only: true,
+        stats_detailed: false,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -576,7 +576,7 @@ fn test_stats_summary_only_plain() {
     let output = result.unwrap();
 
     // Should have the summary line
-    assert!(output.contains("files:"), "Should contain summary");
+    assert!(output.contains("Files:"), "Should contain summary. Got: {}", output);
     // Should NOT have per-file breakdown (lines with " — ")
     assert!(!output.contains(" — "), "summary-only should skip per-file lines");
 }
@@ -592,7 +592,7 @@ fn test_stats_summary_only_json() {
         depth: None,
         format: OutputFormat::Json,
         stats: true,
-        summary_only: true,
+        stats_detailed: false,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -617,4 +617,102 @@ fn test_stats_summary_only_json() {
     // but files count should be > 0
     let files = parsed.get("files").unwrap().as_u64().unwrap();
     assert!(files > 0, "should still report file count");
+}
+
+#[test]
+fn test_stats_summary_shows_languages() {
+    let options = ProcessOptions {
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Plain,
+        stats: true,
+        stats_detailed: false,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+        outline: false,
+        compact: false,
+    };
+
+    let result = process_path(FIXTURE_DIR, options);
+    assert!(result.is_ok(), "process_path failed: {:?}", result.err());
+    let output = result.unwrap();
+
+    // Summary should include Languages line
+    assert!(output.contains("Languages:"), "Summary should show language breakdown. Got: {}", output);
+    // Should NOT show per-file details
+    assert!(!output.contains(" — "), "Summary mode should not list individual files");
+}
+
+#[test]
+fn test_stats_detailed_shows_per_file() {
+    let options = ProcessOptions {
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Plain,
+        stats: true,
+        stats_detailed: true,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+        outline: false,
+        compact: false,
+    };
+
+    let result = process_path(FIXTURE_DIR, options);
+    assert!(result.is_ok(), "process_path failed: {:?}", result.err());
+    let output = result.unwrap();
+
+    // Detailed mode SHOULD show per-file breakdown
+    assert!(output.contains(" — "), "Detailed mode should list individual files. Got: {}", output);
+}
+
+#[test]
+fn test_stats_summary_shows_dirs() {
+    let options = ProcessOptions {
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Plain,
+        stats: true,
+        stats_detailed: false,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+        outline: false,
+        compact: false,
+    };
+
+    let result = process_path(FIXTURE_DIR, options);
+    assert!(result.is_ok(), "process_path failed: {:?}", result.err());
+    let output = result.unwrap();
+
+    // Summary should include Dirs count
+    assert!(output.contains("Dirs:"), "Summary should show directory count. Got: {}", output);
 }

--- a/tests/javascript_test.rs
+++ b/tests/javascript_test.rs
@@ -11,7 +11,7 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -298,9 +298,9 @@ fn javascript_stats_mode() {
     o.stats = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("files:"), "Missing files count");
-    assert!(output.contains("lines:"), "Missing lines count");
-    assert!(output.contains("bytes:"), "Missing bytes count");
+    assert!(output.contains("Files:"), "Missing files count. Got: {}", output);
+    assert!(output.contains("Lines:"), "Missing lines count");
+    assert!(output.contains("Bytes:"), "Missing bytes count");
 }
 
 // === Per-language visibility filtering (issue #82) ===

--- a/tests/list_symbols_test.rs
+++ b/tests/list_symbols_test.rs
@@ -23,7 +23,7 @@ fn default_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -15,7 +15,7 @@ fn default_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -72,8 +72,8 @@ fn passthrough_stats_mode() {
     let mut opts = default_options();
     opts.stats = true;
     let result = process_path(TOML_FIXTURE, opts).unwrap();
-    assert!(result.contains("lines:"));
-    assert!(result.contains("bytes:"));
+    assert!(result.contains("Lines:"));
+    assert!(result.contains("Bytes:"));
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn passthrough_directory_includes_unsupported() {
     opts.stats = true;
     let result = process_path(FIXTURE_DIR, opts).unwrap();
     // Should include both .rs and .toml/.md/.json/.env files
-    assert!(result.contains("config.toml") || result.contains("files:"));
+    assert!(result.contains("config.toml") || result.contains("Files:"));
     // The file count should be more than just the .rs files (3 rs + 4 unsupported = 7)
 }
 

--- a/tests/python_test.rs
+++ b/tests/python_test.rs
@@ -11,7 +11,7 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -234,9 +234,9 @@ fn python_stats_mode() {
     let mut o = opts();
     o.stats = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
-    assert!(output.contains("files:"), "Missing files count");
-    assert!(output.contains("lines:"), "Missing lines count");
-    assert!(output.contains("bytes:"), "Missing bytes count");
+    assert!(output.contains("Files:"), "Missing files count");
+    assert!(output.contains("Lines:"), "Missing lines count");
+    assert!(output.contains("Bytes:"), "Missing bytes count");
 }
 
 // --- Combined filters ---

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -11,7 +11,7 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -252,7 +252,7 @@ const msg = 'hello'
     o.stats = true;
     o.ext = vec!["vue".to_string()];
     let out = process_path(dir.path().to_str().unwrap(), o).unwrap();
-    assert!(out.contains("files: 1"), "Should find 1 vue file: {out}");
+    assert!(out.contains("Files: 1"), "Should find 1 vue file: {out}");
     assert!(out.contains("vue"), "Should show vue language: {out}");
 }
 
@@ -266,7 +266,7 @@ fn sfc_directory_stats_finds_all_sfc_types() {
     let mut o = opts();
     o.stats = true;
     let out = process_path(dir.path().to_str().unwrap(), o).unwrap();
-    assert!(out.contains("files: 3"), "Should find 3 files: {out}");
+    assert!(out.contains("Files: 3"), "Should find 3 files: {out}");
     assert!(out.contains("vue"), "Should show vue: {out}");
     assert!(out.contains("svelte"), "Should show svelte: {out}");
     assert!(out.contains("astro"), "Should show astro: {out}");

--- a/tests/symbol_not_found_test.rs
+++ b/tests/symbol_not_found_test.rs
@@ -22,7 +22,7 @@ fn default_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
-        summary_only: false,
+        stats_detailed: true,
     }
 }
 

--- a/tests/typescript_test.rs
+++ b/tests/typescript_test.rs
@@ -11,7 +11,7 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, summary_only: false,
+        stats: false, stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -258,9 +258,9 @@ fn ts_stats_mode() {
     o.stats = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("files:"), "Missing files count in stats");
-    assert!(output.contains("lines:"), "Missing lines count in stats");
-    assert!(output.contains("bytes:"), "Missing bytes count in stats");
+    assert!(output.contains("Files:"), "Missing files count in stats");
+    assert!(output.contains("Lines:"), "Missing lines count in stats");
+    assert!(output.contains("Bytes:"), "Missing bytes count in stats");
 }
 
 #[test]


### PR DESCRIPTION
Closes #56

## Changes

- **`--stats` now shows a compact summary** by default: file/dir counts, language breakdown, top directories
- **`--stats-detailed` flag** added for the full per-file breakdown (previous `--stats` behavior)
- Auto-detects large repos (>1000 files) and shows `[Use --stats-detailed for full file list]` hint
- Numbers are formatted with comma separators or abbreviated (e.g. `8.2k`)
- Replaced `--summary-only` flag (inverted default: summary is now the default)

## Testing

- 3 new tests: summary shows languages, summary shows dirs, detailed shows per-file
- All existing tests updated and passing