### PR TITLE
feat: add --list-symbols --minimal mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub struct ProcessOptions {
     pub exclude: Vec<String>,
     pub outline: bool,
     pub compact: bool,
+    pub minimal: bool,
 }
 
 /// Process a file or directory and return formatted output

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,10 @@ struct Cli {
     #[arg(long = "symbol-depth", requires = "list_symbols")]
     symbol_depth: Option<usize>,
 
+    /// Minimal output for --list-symbols: bare symbol names only, one per line
+    #[arg(long, requires = "list_symbols")]
+    minimal: bool,
+
     /// Extract a line range with structural context (e.g. --lines 50-75)
     #[arg(long)]
     lines: Option<String>,
@@ -572,6 +576,7 @@ fn main() {
                 exclude: cli.exclude,
                 outline: cli.outline,
                 compact: cli.compact,
+                minimal: cli.minimal,
             };
             
             match process_path(&path, options) {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -84,6 +84,16 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
     Ok(serde_json::to_string_pretty(&result)?)
 }
 
+pub fn format_list_symbols_minimal(files: &[(String, Vec<Item>)]) -> Result<String, CodehudError> {
+    let names: Vec<&str> = files
+        .iter()
+        .flat_map(|(_, items)| items.iter())
+        .map(|item| item.name.as_deref().unwrap_or("-"))
+        .collect();
+
+    Ok(serde_json::to_string_pretty(&names)?)
+}
+
 /// Format items as JSON
 pub fn format_output(files: &[(String, Vec<Item>)]) -> Result<String, CodehudError> {
     let files_output: Vec<FileOutput> = files

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -95,6 +95,20 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
     Ok(output)
 }
 
+pub fn format_list_symbols_minimal(files: &[(String, Vec<Item>)]) -> Result<String, CodehudError> {
+    use std::fmt::Write;
+    let mut output = String::new();
+
+    for (_file_path, items) in files {
+        for item in items {
+            let name = item.name.as_deref().unwrap_or("-");
+            writeln!(output, "{}", name).unwrap();
+        }
+    }
+
+    Ok(output)
+}
+
 /// Format outline mode: signatures + docstrings without line numbers.
 pub fn format_outline(files: &[(String, Vec<Item>)]) -> Result<String, CodehudError> {
     let mut output = String::new();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -386,9 +386,16 @@ pub(crate) fn format_output(
             OutputFormat::Plain => output::plain::format_outline(filtered),
         }
     } else if options.list_symbols {
-        match options.format {
-            OutputFormat::Json => output::json::format_list_symbols(filtered),
-            OutputFormat::Plain => output::plain::format_list_symbols(filtered),
+        if options.minimal {
+            match options.format {
+                OutputFormat::Json => output::json::format_list_symbols_minimal(filtered),
+                OutputFormat::Plain => output::plain::format_list_symbols_minimal(filtered),
+            }
+        } else {
+            match options.format {
+                OutputFormat::Json => output::json::format_list_symbols(filtered),
+                OutputFormat::Plain => output::plain::format_list_symbols(filtered),
+            }
         }
 
 
@@ -440,6 +447,7 @@ mod tests {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         }
     }
 

--- a/tests/compact_test.rs
+++ b/tests/compact_test.rs
@@ -21,6 +21,7 @@ fn outline_options(compact: bool) -> ProcessOptions {
         exclude: vec![],
         outline: true,
         compact,
+        minimal: false,
     }
 }
 

--- a/tests/display_names_test.rs
+++ b/tests/display_names_test.rs
@@ -20,6 +20,7 @@ fn list_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 }
 

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -21,6 +21,7 @@ fn default_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 }
 
@@ -48,6 +49,7 @@ fn exclude_single_directory() {
         exclude: vec!["dist".to_string()],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -63,6 +65,7 @@ fn exclude_multiple_directories() {
         exclude: vec!["dist".to_string(), "generated".to_string()],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -78,6 +81,7 @@ fn exclude_glob_pattern() {
         exclude: vec!["*.js".to_string()],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -95,6 +99,7 @@ fn exclude_with_ext_filter() {
         exclude: vec!["src".to_string()],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -166,6 +171,7 @@ fn exclude_wildcard_path_pattern() {
         exclude: vec!["*/migrations/*".to_string()],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,6 +22,7 @@ fn test_interface_mode_basic() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -58,6 +59,7 @@ fn test_expand_mode() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -91,6 +93,7 @@ fn test_expand_function() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -122,6 +125,7 @@ fn test_pub_filter() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -156,6 +160,7 @@ fn test_fns_filter() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -191,6 +196,7 @@ fn test_types_filter() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -227,6 +233,7 @@ fn test_combined_pub_fns() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -265,6 +272,7 @@ fn test_json_output() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -304,6 +312,7 @@ fn test_nonexistent_path() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -332,6 +341,7 @@ fn test_directory_mode() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -363,6 +373,7 @@ fn test_expand_nonexistent_symbol() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
     
@@ -396,6 +407,7 @@ fn test_no_tests_filter() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
 
@@ -434,6 +446,7 @@ fn test_no_tests_filter_disabled() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
 
@@ -466,6 +479,7 @@ fn test_stats_output_plain() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
 
@@ -499,6 +513,7 @@ fn test_stats_output_json() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
 
@@ -536,6 +551,7 @@ fn test_stats_with_directory() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     
 };
 
@@ -569,6 +585,7 @@ fn test_stats_summary_only_plain() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -603,6 +620,7 @@ fn test_stats_summary_only_json() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -641,6 +659,7 @@ fn test_stats_summary_shows_languages() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -675,6 +694,7 @@ fn test_stats_detailed_shows_per_file() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -707,6 +727,7 @@ fn test_stats_summary_shows_dirs() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);

--- a/tests/javascript_test.rs
+++ b/tests/javascript_test.rs
@@ -22,6 +22,7 @@ fn opts() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 
 }

--- a/tests/list_symbols_test.rs
+++ b/tests/list_symbols_test.rs
@@ -34,6 +34,7 @@ fn default_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 }
 
@@ -73,6 +74,7 @@ fn test_list_symbols_smaller_than_interface() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let interface_output = process_path(FIXTURE_PATH, interface_opts).unwrap();
@@ -166,6 +168,7 @@ fn test_list_symbols_no_imports_excludes_use() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -186,6 +189,7 @@ fn test_list_symbols_without_no_imports_includes_use() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -262,6 +266,7 @@ fn test_list_symbols_no_imports_typescript() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/imports_sample.ts", options).unwrap();
@@ -289,6 +294,7 @@ fn test_list_symbols_vue_sfc_depth_2_shows_class_members() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -307,6 +313,7 @@ fn test_list_symbols_vue_sfc_depth_1_hides_class_members() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -340,6 +347,7 @@ fn test_list_symbols_depth_2_shows_class_members() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/sample.ts", options).unwrap();
@@ -355,6 +363,7 @@ fn test_list_symbols_depth_2_json_includes_methods() {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         format: OutputFormat::Json,
         ..default_options()
     };
@@ -459,4 +468,44 @@ fn test_cli_json_list_symbols_not_plain_text() {
     // JSON output MUST be valid JSON  
     assert!(serde_json::from_str::<serde_json::Value>(&json_output).is_ok(),
         "--json --list-symbols MUST be valid JSON, got:\n{}", &json_output[..json_output.len().min(200)]);
+}
+
+#[test]
+fn test_minimal_outputs_bare_names() {
+    let mut options = default_options();
+    options.minimal = true;
+    let output = process_path(FIXTURE_PATH, options).unwrap();
+    // Each line should be a bare name with no type/location info
+    for line in output.lines() {
+        assert!(!line.contains("L"), "minimal mode should not contain line numbers: {}", line);
+        assert!(!line.contains("fn "), "minimal mode should not contain kind labels: {}", line);
+        assert!(!line.contains("struct "), "minimal mode should not contain kind labels: {}", line);
+    }
+    // Should contain known symbols from sample.rs
+    let names: Vec<&str> = output.lines().collect();
+    assert!(!names.is_empty(), "minimal mode should output symbol names");
+}
+
+#[test]
+fn test_cli_minimal_flag() {
+    let output = run_codehud(&["--list-symbols", "--minimal", FIXTURE_PATH]);
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert!(!lines.is_empty());
+    // No line should contain whitespace-padded columns or line numbers
+    for line in &lines {
+        assert!(!line.contains("  "), "minimal output should not have padded columns: {}", line);
+    }
+}
+
+#[test]
+fn test_cli_minimal_json() {
+    let output = run_codehud(&["--list-symbols", "--minimal", "--json", FIXTURE_PATH]);
+    let parsed: serde_json::Value = serde_json::from_str(&output)
+        .expect("--minimal --json should output valid JSON");
+    let arr = parsed.as_array().expect("should be an array of names");
+    assert!(!arr.is_empty());
+    // All entries should be strings (bare names)
+    for entry in arr {
+        assert!(entry.is_string(), "each entry should be a string, got: {}", entry);
+    }
 }

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -26,6 +26,7 @@ fn default_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 }
 

--- a/tests/python_test.rs
+++ b/tests/python_test.rs
@@ -22,6 +22,7 @@ fn opts() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 
 }

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -22,6 +22,7 @@ fn opts() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 }
 

--- a/tests/symbol_not_found_test.rs
+++ b/tests/symbol_not_found_test.rs
@@ -22,6 +22,7 @@ fn default_options() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
         stats_detailed: true,
     }
 }

--- a/tests/typescript_test.rs
+++ b/tests/typescript_test.rs
@@ -22,6 +22,7 @@ fn opts() -> ProcessOptions {
         exclude: vec![],
         outline: false,
         compact: false,
+        minimal: false,
     }
 
 }


### PR DESCRIPTION
When `--list-symbols --minimal` is used, output only bare symbol names (one per line), no types, locations, or metadata. Default `--list-symbols` stays unchanged.

- Adds `--minimal` flag (requires `--list-symbols`)
- Plain mode: one name per line
- JSON mode: flat array of name strings
- 3 new tests

Refs #63