### PR TITLE
feat: add --outline --expand for inline expansion (refs #60)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub struct ProcessOptions {
     pub outline: bool,
     pub compact: bool,
     pub minimal: bool,
+    pub expand_symbols: Vec<String>,
 }
 
 /// Process a file or directory and return formatted output
@@ -213,6 +214,90 @@ fn parse_line_range(arg: &str) -> Result<(usize, usize), CodehudError> {
     Ok((start, end))
 }
 
+/// Inline-expand named symbols within outline items.
+///
+/// For top-level symbols, replaces the outline content with the full expanded source.
+/// For methods/members inside containers (impl/class/trait), replaces just that
+/// member's signature line within the container's outline content with the full source.
+fn inline_expand_symbols(
+    items: &mut [Item],
+    source: &str,
+    tree: &tree_sitter::Tree,
+    expand_symbols: &[String],
+    language: Language,
+) {
+    let expanded = expand_with_dispatch(source, tree, expand_symbols, language);
+
+    for item in items.iter_mut() {
+        // Check if this top-level item matches an expand symbol
+        if let Some(ref name) = item.name
+            && let Some(exp) = expanded.iter().find(|e| e.name.as_deref() == Some(name.as_str()))
+        {
+            item.content = exp.content.clone();
+            item.body = exp.body.clone();
+            item.signature = exp.signature.clone();
+            continue;
+        }
+
+        // For containers (impl/class/trait), check if any expanded symbol is a member
+        if matches!(item.kind, ItemKind::Class | ItemKind::Impl | ItemKind::Trait) {
+            for exp in &expanded {
+                if let Some(ref exp_name) = exp.name {
+                    // Check if this expanded item's line range falls within the container
+                    if exp.line_start >= item.line_start && exp.line_end <= item.line_end {
+                        // Get the full source of the expanded method
+                        let full_source = &exp.content;
+                        // Find the signature line in the container outline and replace it
+                        item.content = replace_member_in_outline(&item.content, exp_name, full_source);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Replace a member's signature line in a container outline with its full source.
+fn replace_member_in_outline(outline: &str, member_name: &str, full_source: &str) -> String {
+    let mut result = Vec::new();
+    let lines: Vec<&str> = outline.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+        // Match signature lines like "    fn greeting (&self) -> String" or "    pub fn new (...) -> Self"
+        if (trimmed.contains(&format!("fn {member_name} ")) || trimmed.contains(&format!("fn {member_name}("))) 
+            && !trimmed.contains('{')  // not already expanded
+        {
+            // Replace with indented full source
+            for src_line in full_source.lines() {
+                // The expanded content from expand_with_dispatch has line numbers like "16 | ..."
+                // Strip line number prefix if present
+                if let Some(pos) = src_line.find(" | ") {
+                    let before = &src_line[..pos];
+                    if before.trim().chars().all(|c| c.is_ascii_digit()) {
+                        result.push(format!("    {}", &src_line[pos + 3..]));
+                        continue;
+                    }
+                }
+                result.push(format!("    {}", src_line));
+            }
+            // Skip continuation line of a multi-line signature (e.g. closing paren on next line)
+            if i + 1 < lines.len() {
+                let next = lines[i + 1].trim();
+                let is_boundary = next.is_empty() || next.starts_with("fn ") || next.starts_with("pub ")
+                    || next == "}" || next.starts_with("///") || next.starts_with("/**")
+                    || next.starts_with("#[") || next.starts_with("@");
+                if !is_boundary && next.contains(')') && !next.contains('{') {
+                    i += 1;
+                }
+            }
+        } else {
+            result.push(lines[i].to_string());
+        }
+        i += 1;
+    }
+    result.join("\n")
+}
+
 /// Expand symbols with dispatch-based fallback for dot-notation and bare method names.
 fn expand_with_dispatch(
     source: &str,
@@ -291,6 +376,7 @@ fn process_file(
     pub_only: bool,
     outline: bool,
     compact: bool,
+    expand_symbols: &[String],
 ) -> Result<(Vec<Item>, usize, usize), CodehudError> {
     let source = fs::read_to_string(path)
         .map_err(|e| CodehudError::ReadError {
@@ -339,7 +425,11 @@ fn process_file(
             } else if expand_mode {
                 expand_with_dispatch(&block.content, &tree, symbols, block.language)
             } else if outline {
-                extractor::outline::extract_outline(&block.content, &tree, block.language, pub_only, compact)
+                let mut items = extractor::outline::extract_outline(&block.content, &tree, block.language, pub_only, compact);
+                if !expand_symbols.is_empty() {
+                    inline_expand_symbols(&mut items, &block.content, &tree, expand_symbols, block.language);
+                }
+                items
             } else {
                 extractor::interface::extract_filtered(&block.content, &tree, block.language, pub_only)
             };
@@ -403,7 +493,11 @@ fn process_file(
     } else if expand_mode {
         expand_with_dispatch(&source, &tree, symbols, language)
     } else if outline {
-        extractor::outline::extract_outline(&source, &tree, language, pub_only, compact)
+        let mut items = extractor::outline::extract_outline(&source, &tree, language, pub_only, compact);
+        if !expand_symbols.is_empty() {
+            inline_expand_symbols(&mut items, &source, &tree, expand_symbols, language);
+        }
+        items
     } else {
         extractor::interface::extract_filtered(&source, &tree, language, pub_only)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,10 @@ struct Cli {
     #[arg(long, requires = "outline")]
     compact: bool,
 
+    /// Expand named symbols inline within --outline (comma-separated symbol names)
+    #[arg(long = "expand", value_delimiter = ',', requires = "outline")]
+    expand_symbols: Vec<String>,
+
     /// Truncate expanded symbol output after N lines
     #[arg(long = "max-lines")]
     max_lines: Option<usize>,
@@ -577,6 +581,7 @@ fn main() {
                 outline: cli.outline,
                 compact: cli.compact,
                 minimal: cli.minimal,
+                expand_symbols: cli.expand_symbols,
             };
             
             match process_path(&path, options) {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -37,7 +37,7 @@ pub(crate) fn collect_and_extract(
     };
 
     if path.is_file() {
-        let (items, lines, bytes) = process_file(path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact)?;
+        let (items, lines, bytes) = process_file(path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact, &options.expand_symbols)?;
         return Ok(vec![FileItems {
             path: path.to_string_lossy().to_string(),
             items,
@@ -63,7 +63,7 @@ pub(crate) fn collect_and_extract(
         if options.no_tests && test_detect::is_test_file_any_language(&file_path) {
             continue;
         }
-        match process_file(&file_path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact) {
+        match process_file(&file_path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact, &options.expand_symbols) {
             Ok((items, lines, bytes)) => {
                 if expand_mode && !items.is_empty() {
                     for item in &items {
@@ -448,6 +448,7 @@ mod tests {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         }
     }
 

--- a/tests/compact_test.rs
+++ b/tests/compact_test.rs
@@ -22,6 +22,7 @@ fn outline_options(compact: bool) -> ProcessOptions {
         outline: true,
         compact,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 

--- a/tests/display_names_test.rs
+++ b/tests/display_names_test.rs
@@ -21,6 +21,7 @@ fn list_options() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -22,6 +22,7 @@ fn default_options() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 
@@ -50,6 +51,7 @@ fn exclude_single_directory() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -66,6 +68,7 @@ fn exclude_multiple_directories() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -82,6 +85,7 @@ fn exclude_glob_pattern() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -100,6 +104,7 @@ fn exclude_with_ext_filter() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -172,6 +177,7 @@ fn exclude_wildcard_path_pattern() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -23,6 +23,7 @@ fn test_interface_mode_basic() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -60,6 +61,7 @@ fn test_expand_mode() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -94,6 +96,7 @@ fn test_expand_function() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -126,6 +129,7 @@ fn test_pub_filter() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -161,6 +165,7 @@ fn test_fns_filter() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -197,6 +202,7 @@ fn test_types_filter() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -234,6 +240,7 @@ fn test_combined_pub_fns() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -273,6 +280,7 @@ fn test_json_output() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -313,6 +321,7 @@ fn test_nonexistent_path() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -342,6 +351,7 @@ fn test_directory_mode() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -374,6 +384,7 @@ fn test_expand_nonexistent_symbol() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
     
@@ -408,6 +419,7 @@ fn test_no_tests_filter() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
 
@@ -447,6 +459,7 @@ fn test_no_tests_filter_disabled() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
 
@@ -480,6 +493,7 @@ fn test_stats_output_plain() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
 
@@ -514,6 +528,7 @@ fn test_stats_output_json() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
 
@@ -552,6 +567,7 @@ fn test_stats_with_directory() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     
 };
 
@@ -586,6 +602,7 @@ fn test_stats_summary_only_plain() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -621,6 +638,7 @@ fn test_stats_summary_only_json() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -660,6 +678,7 @@ fn test_stats_summary_shows_languages() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -695,6 +714,7 @@ fn test_stats_detailed_shows_per_file() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -728,6 +748,7 @@ fn test_stats_summary_shows_dirs() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     };
 
     let result = process_path(FIXTURE_DIR, options);

--- a/tests/javascript_test.rs
+++ b/tests/javascript_test.rs
@@ -23,6 +23,7 @@ fn opts() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 
 }

--- a/tests/list_symbols_test.rs
+++ b/tests/list_symbols_test.rs
@@ -35,6 +35,7 @@ fn default_options() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 
@@ -75,6 +76,7 @@ fn test_list_symbols_smaller_than_interface() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let interface_output = process_path(FIXTURE_PATH, interface_opts).unwrap();
@@ -169,6 +171,7 @@ fn test_list_symbols_no_imports_excludes_use() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -190,6 +193,7 @@ fn test_list_symbols_without_no_imports_includes_use() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
@@ -267,6 +271,7 @@ fn test_list_symbols_no_imports_typescript() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path("tests/fixtures/imports_sample.ts", options).unwrap();
@@ -295,6 +300,7 @@ fn test_list_symbols_vue_sfc_depth_2_shows_class_members() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -314,6 +320,7 @@ fn test_list_symbols_vue_sfc_depth_1_hides_class_members() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
@@ -348,6 +355,7 @@ fn test_list_symbols_depth_2_shows_class_members() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         ..default_options()
     };
     let output = process_path("tests/fixtures/sample.ts", options).unwrap();
@@ -364,6 +372,7 @@ fn test_list_symbols_depth_2_json_includes_methods() {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         format: OutputFormat::Json,
         ..default_options()
     };

--- a/tests/outline_expand_test.rs
+++ b/tests/outline_expand_test.rs
@@ -1,0 +1,87 @@
+use codehud::{process_path, ProcessOptions, OutputFormat};
+
+fn outline_expand_options(expand: Vec<&str>) -> ProcessOptions {
+    ProcessOptions {
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: false,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+        outline: true,
+        compact: false,
+        minimal: false,
+        expand_symbols: expand.into_iter().map(String::from).collect(),
+    }
+}
+
+#[test]
+fn outline_expand_shows_full_body_for_named_symbol() {
+    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting"])).unwrap();
+    // The expanded symbol should contain its body (implementation)
+    assert!(output.contains("format!"), "expanded symbol 'greet' should show its body with format!: {}", output);
+}
+
+#[test]
+fn outline_expand_keeps_other_symbols_as_signatures() {
+    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting"])).unwrap();
+    // 'new' should still be in outline (signature-only) form — no body
+    // The outline for 'new' in an impl block shows signature only
+    assert!(output.contains("fn new"), "outline should still contain 'new' signature: {}", output);
+}
+
+#[test]
+fn outline_expand_no_expand_is_normal_outline() {
+    let normal = process_path("tests/fixtures/sample.rs", outline_expand_options(vec![])).unwrap();
+    let outline_only = process_path("tests/fixtures/sample.rs", ProcessOptions {
+        outline: true,
+        compact: false,
+        minimal: false,
+        expand_symbols: vec![],
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: false,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+    }).unwrap();
+    assert_eq!(normal, outline_only, "empty expand should produce same output as plain outline");
+}
+
+#[test]
+fn outline_expand_top_level_function() {
+    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["public_utility"])).unwrap();
+    // Top-level function should be fully expanded
+    assert!(output.contains("to_uppercase"), "expanded top-level fn should show body: {}", output);
+    // Other functions should remain as signatures
+    assert!(!output.contains("true"), "private_helper should stay as signature (no body 'true'): {}", output);
+}
+
+#[test]
+fn outline_expand_multiple_symbols() {
+    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting", "new"])).unwrap();
+    // Both should be expanded with their bodies
+    assert!(output.contains("format!"), "greet should be expanded: {}", output);
+}

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -27,6 +27,7 @@ fn default_options() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 

--- a/tests/python_test.rs
+++ b/tests/python_test.rs
@@ -23,6 +23,7 @@ fn opts() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 
 }

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -23,6 +23,7 @@ fn opts() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 }
 

--- a/tests/symbol_not_found_test.rs
+++ b/tests/symbol_not_found_test.rs
@@ -23,6 +23,7 @@ fn default_options() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
         stats_detailed: true,
     }
 }

--- a/tests/typescript_test.rs
+++ b/tests/typescript_test.rs
@@ -23,6 +23,7 @@ fn opts() -> ProcessOptions {
         outline: false,
         compact: false,
         minimal: false,
+        expand_symbols: vec![],
     }
 
 }


### PR DESCRIPTION
When `--outline --expand symbol1,symbol2` is used together, the outline shows all symbols in signature-only form except the named symbols, which are fully expanded inline with their complete source.

## Changes
- Added `--expand` CLI flag (comma-separated, requires `--outline`)
- Added `expand_symbols` field to `ProcessOptions`
- Implemented `inline_expand_symbols()` that handles both top-level symbols and methods inside containers (impl/class/trait)
- Added 5 tests covering: method expansion, top-level fn expansion, multiple symbols, no-op with empty expand, signature preservation

## Usage
```bash
codehud src/lib.rs --outline --expand process_path,extract_lines
```

Fixes #60