### PR TITLE
feat: add OpenCode install-skill adapter

### DIFF
--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -1,5 +1,6 @@
 pub mod content;
 mod openclaw;
+mod opencode;
 mod claude_code;
 mod codex;
 mod cursor;
@@ -18,7 +19,7 @@ pub trait PlatformAdapter {
 }
 
 /// All supported platform names.
-pub const PLATFORMS: &[&str] = &["openclaw", "claude-code", "codex", "cursor", "aider"];
+pub const PLATFORMS: &[&str] = &["openclaw", "open-code", "claude-code", "codex", "cursor", "aider"];
 
 /// List all available platforms to stdout.
 pub fn list_platforms() {
@@ -32,6 +33,7 @@ pub fn list_platforms() {
 fn get_adapter(platform: &str) -> Result<Box<dyn PlatformAdapter>, CodehudError> {
     match platform {
         "openclaw" => Ok(Box::new(openclaw::OpenClawAdapter)),
+        "opencode" => Ok(Box::new(opencode::OpenCodeAdapter)),
         "claude-code" => Ok(Box::new(claude_code::ClaudeCodeAdapter)),
         "codex" => Ok(Box::new(codex::CodexAdapter)),
         "cursor" => Ok(Box::new(cursor::CursorAdapter)),

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -19,7 +19,7 @@ pub trait PlatformAdapter {
 }
 
 /// All supported platform names.
-pub const PLATFORMS: &[&str] = &["openclaw", "open-code", "claude-code", "codex", "cursor", "aider"];
+pub const PLATFORMS: &[&str] = &["openclaw", "opencode", "claude-code", "codex", "cursor", "aider"];
 
 /// List all available platforms to stdout.
 pub fn list_platforms() {

--- a/src/skill/opencode.rs
+++ b/src/skill/opencode.rs
@@ -1,0 +1,69 @@
+use super::content::SKILL_CONTENT;
+use super::PlatformAdapter;
+use crate::CodehudError;
+use std::fs;
+use std::path::PathBuf;
+use tracing::{debug, info};
+
+pub struct OpenCodeAdapter;
+
+const FRONTMATTER: &str = r#"---
+name: codehud
+description: "Tree-sitter powered structural code intelligence. Use for code exploration, symbol lookup, cross-references, and structural diff."
+metadata:
+  opencode:
+    emoji: "🧠"
+    requires:
+      bins: ["codehud"]
+    install:
+      - id: cargo
+        kind: shell
+        command: "cargo install codehud"
+        bins: ["codehud"]
+        label: "Install codehud (cargo)"
+      - id: script
+        kind: shell
+        command: "curl -fsSL https://raw.githubusercontent.com/Tidemarks-AI/Code-HUD/main/install.sh | sh"
+        bins: ["codehud"]
+        label: "Install codehud (install script)"
+---
+"#;
+
+fn skill_dir() -> Result<PathBuf, CodehudError> {
+    Ok(dirs::home_dir()
+        .ok_or(CodehudError::HomeDir)?
+        .join(".opencode/skills/codehud"))
+}
+
+impl PlatformAdapter for OpenCodeAdapter {
+    fn install(&self, _global: bool) -> Result<(), CodehudError> {
+        let dir = skill_dir()?;
+        fs::create_dir_all(&dir)?;
+        let path = dir.join("SKILL.md");
+        let content = format!("{}\n{}\n", FRONTMATTER.trim(), SKILL_CONTENT.trim());
+        fs::write(&path, content)?;
+        info!(path = %path.display(), "Installed codehud skill");
+        println!("Installed codehud skill to {}", path.display());
+        Ok(())
+    }
+
+    fn uninstall(&self, _global: bool) -> Result<(), CodehudError> {
+        let dir = skill_dir()?;
+        let path = dir.join("SKILL.md");
+        if path.exists() {
+            fs::remove_file(&path)?;
+            info!(path = %path.display(), "Removed codehud skill");
+            println!("Removed {}", path.display());
+        }
+        if dir.exists() && fs::read_dir(&dir)?.next().is_none() {
+            fs::remove_dir(&dir)?;
+            debug!(dir = %dir.display(), "Removed empty skill directory");
+            println!("Removed empty directory {}", dir.display());
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "OpenCode"
+    }
+}


### PR DESCRIPTION
Add OpenCode install-skill adapter
Add support for installing the codehud skill into OpenCode via codehud install-skill opencode.

Changes:
- New OpenCodeAdapter (`src/skill/opencode.rs`)
- Registers opencode in `src/skill/mod.rs`
- Installs skill to `~/.opencode/skills/codehud/SKILL.md`
- Writes:
  - YAML frontmatter with metadata.opencode
  - requires.bins: ["codehud"]
  - Two install options (cargo install codehud and install script)
  - Shared SKILL_CONTENT
- uninstall-skill opencode removes the skill file and cleans up empty directories

Usage
`codehud install-skill opencode`
`codehud uninstall-skill opencode`