### PR TITLE
feat: add per-language doc comment extraction with --with-comments flag

### DIFF
--- a/src/agent/openclaw.rs
+++ b/src/agent/openclaw.rs
@@ -172,9 +172,7 @@ fn remove_agent_from_config(config: &mut serde_json::Value) -> Result<bool, Code
         .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     let before = agents_list.len();
-    agents_list.retain(|entry| {
-        entry.get("id").and_then(|v| v.as_str()) != Some(AGENT_ID)
-    });
+    agents_list.retain(|entry| entry.get("id").and_then(|v| v.as_str()) != Some(AGENT_ID));
     Ok(agents_list.len() < before)
 }
 
@@ -187,22 +185,28 @@ fn add_to_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, Codehu
 
     // Find the main/default agent
     for entry in agents_list.iter_mut() {
-        let is_main = entry.get("default").and_then(|v| v.as_bool()).unwrap_or(false)
+        let is_main = entry
+            .get("default")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
             || entry.get("id").and_then(|v| v.as_str()) == Some("main");
 
         if is_main {
             // Navigate to subagents.allowAgents, creating if needed
-            let entry_obj = entry.as_object_mut()
+            let entry_obj = entry
+                .as_object_mut()
                 .ok_or_else(|| CodehudError::Config("agent entry is not an object".to_string()))?;
             let subagents = entry_obj
                 .entry("subagents")
                 .or_insert_with(|| serde_json::json!({}));
-            let subagents_obj = subagents.as_object_mut()
+            let subagents_obj = subagents
+                .as_object_mut()
                 .ok_or_else(|| CodehudError::Config("subagents is not an object".to_string()))?;
             let allow = subagents_obj
                 .entry("allowAgents")
                 .or_insert_with(|| serde_json::json!([]));
-            let arr = allow.as_array_mut()
+            let arr = allow
+                .as_array_mut()
                 .ok_or_else(|| CodehudError::Config("allowAgents is not an array".to_string()))?;
 
             if arr.iter().any(|v| v.as_str() == Some(AGENT_ID)) {
@@ -224,7 +228,10 @@ fn remove_from_spawn_allowlist(config: &mut serde_json::Value) -> Result<bool, C
         .ok_or_else(|| CodehudError::Config("agents.list not found in config".to_string()))?;
 
     for entry in agents_list.iter_mut() {
-        let is_main = entry.get("default").and_then(|v| v.as_bool()).unwrap_or(false)
+        let is_main = entry
+            .get("default")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
             || entry.get("id").and_then(|v| v.as_str()) == Some("main");
 
         if is_main {
@@ -326,7 +333,10 @@ impl AgentAdapter for OpenClawAdapter {
                 info!(workspace = %ws.display(), "Removed agent workspace");
                 println!("✓ Removed workspace at {}", ws.display());
             } else {
-                println!("  Workspace preserved at {} (use --force to remove)", ws.display());
+                println!(
+                    "  Workspace preserved at {} (use --force to remove)",
+                    ws.display()
+                );
             }
         }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -188,14 +188,15 @@ pub fn diff_symbols(
     // Modified: in both, body differs
     for (qname, old) in &old_map {
         if let Some(new) = new_map.get(qname)
-            && old.body_hash != new.body_hash {
-                let sig_changed = old.signature != new.signature;
-                changes.push(SymbolChange::Modified {
-                    old: (*old).clone(),
-                    new: (*new).clone(),
-                    signature_changed: sig_changed,
-                });
-            }
+            && old.body_hash != new.body_hash
+        {
+            let sig_changed = old.signature != new.signature;
+            changes.push(SymbolChange::Modified {
+                old: (*old).clone(),
+                new: (*new).clone(),
+                signature_changed: sig_changed,
+            });
+        }
     }
 
     Ok(changes)
@@ -271,7 +272,13 @@ mod tests {
         let new = "fn foo() { 2 + 2 }";
         let changes = diff_symbols(old, new, Language::Rust).unwrap();
         assert_eq!(changes.len(), 1);
-        assert!(matches!(&changes[0], SymbolChange::Modified { signature_changed: false, .. }));
+        assert!(matches!(
+            &changes[0],
+            SymbolChange::Modified {
+                signature_changed: false,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -280,7 +287,13 @@ mod tests {
         let new = "fn foo(x: i32) {}";
         let changes = diff_symbols(old, new, Language::Rust).unwrap();
         assert_eq!(changes.len(), 1);
-        assert!(matches!(&changes[0], SymbolChange::Modified { signature_changed: true, .. }));
+        assert!(matches!(
+            &changes[0],
+            SymbolChange::Modified {
+                signature_changed: true,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -312,9 +325,18 @@ export class Foo {
 "#;
         let changes = diff_symbols(old, new, Language::TypeScript).unwrap();
         // Should detect bar modified and baz added
-        let added: Vec<_> = changes.iter().filter(|c| matches!(c, SymbolChange::Added(_))).collect();
-        let modified: Vec<_> = changes.iter().filter(|c| matches!(c, SymbolChange::Modified { .. })).collect();
-        assert!(!added.is_empty() || !modified.is_empty(), "expected changes, got none");
+        let added: Vec<_> = changes
+            .iter()
+            .filter(|c| matches!(c, SymbolChange::Added(_)))
+            .collect();
+        let modified: Vec<_> = changes
+            .iter()
+            .filter(|c| matches!(c, SymbolChange::Modified { .. }))
+            .collect();
+        assert!(
+            !added.is_empty() || !modified.is_empty(),
+            "expected changes, got none"
+        );
     }
 
     #[test]
@@ -322,7 +344,10 @@ export class Foo {
         let old = "def foo():\n    pass\n";
         let new = "def foo():\n    return 1\ndef bar():\n    pass\n";
         let changes = diff_symbols(old, new, Language::Python).unwrap();
-        let added: Vec<_> = changes.iter().filter(|c| matches!(c, SymbolChange::Added(_))).collect();
+        let added: Vec<_> = changes
+            .iter()
+            .filter(|c| matches!(c, SymbolChange::Added(_)))
+            .collect();
         assert_eq!(added.len(), 1);
     }
 
@@ -332,7 +357,13 @@ export class Foo {
         let new = "pub struct Foo { x: i32, y: i32 }";
         let changes = diff_symbols(old, new, Language::Rust).unwrap();
         // At least one modified change for Foo
-        let modified: Vec<_> = changes.iter().filter(|c| matches!(c, SymbolChange::Modified { .. })).collect();
-        assert!(!modified.is_empty(), "expected at least one modified symbol");
+        let modified: Vec<_> = changes
+            .iter()
+            .filter(|c| matches!(c, SymbolChange::Modified { .. }))
+            .collect();
+        assert!(
+            !modified.is_empty(),
+            "expected at least one modified symbol"
+        );
     }
 }

--- a/src/diff_cli.rs
+++ b/src/diff_cli.rs
@@ -37,9 +37,7 @@ pub fn run_diff(opts: &DiffOptions) -> Result<String, CodehudError> {
             let pb = std::path::PathBuf::from(p);
             // git -C requires a directory; if the path is a file, use its parent
             if pb.is_file() {
-                pb.parent()
-                    .map(|d| d.to_path_buf())
-                    .unwrap_or(pb)
+                pb.parent().map(|d| d.to_path_buf()).unwrap_or(pb)
             } else {
                 pb
             }
@@ -176,11 +174,7 @@ fn diff_one_file(
         }
     };
 
-    let changes = diff::diff_symbols_tolerant(
-        old_src.as_deref(),
-        new_src.as_deref(),
-        language,
-    );
+    let changes = diff::diff_symbols_tolerant(old_src.as_deref(), new_src.as_deref(), language);
 
     if changes.is_empty() {
         return Ok(None);
@@ -196,7 +190,11 @@ fn diff_one_file(
 // Filters
 // ---------------------------------------------------------------------------
 
-fn filter_by_scope(changes: Vec<FileChange>, scope: &Option<String>, root: &str) -> Vec<FileChange> {
+fn filter_by_scope(
+    changes: Vec<FileChange>,
+    scope: &Option<String>,
+    root: &str,
+) -> Vec<FileChange> {
     let scope = match scope {
         Some(s) => s,
         None => return changes,
@@ -206,9 +204,7 @@ fn filter_by_scope(changes: Vec<FileChange>, scope: &Option<String>, root: &str)
     let scope_abs = if Path::new(scope).is_absolute() {
         std::path::PathBuf::from(scope)
     } else {
-        std::env::current_dir()
-            .unwrap_or_default()
-            .join(scope)
+        std::env::current_dir().unwrap_or_default().join(scope)
     };
     let scope_abs = scope_abs.canonicalize().unwrap_or(scope_abs);
     let root_path = Path::new(root);
@@ -286,7 +282,10 @@ fn is_type_symbol(change: &SymbolChange) -> bool {
         SymbolChange::Deleted(s) => &s.kind,
         SymbolChange::Modified { new, .. } => &new.kind,
     };
-    matches!(kind, ItemKind::Class | ItemKind::Struct | ItemKind::Enum | ItemKind::Trait)
+    matches!(
+        kind,
+        ItemKind::Class | ItemKind::Struct | ItemKind::Enum | ItemKind::Trait
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -310,12 +309,13 @@ fn format_plain(diffs: &[FileDiff]) -> String {
                     ));
                 }
                 SymbolChange::Deleted(s) => {
-                    out.push_str(&format!(
-                        "    - {} — deleted\n",
-                        s.qualified_name
-                    ));
+                    out.push_str(&format!("    - {} — deleted\n", s.qualified_name));
                 }
-                SymbolChange::Modified { new, signature_changed, .. } => {
+                SymbolChange::Modified {
+                    new,
+                    signature_changed,
+                    ..
+                } => {
                     if *signature_changed {
                         out.push_str(&format!(
                             "    ~ {} (L{}-{}) — signature changed\n",
@@ -353,7 +353,11 @@ fn format_json(diffs: &[FileDiff]) -> Result<String, CodehudError> {
                     "change_type": "deleted",
                     "old_range": [s.line_start, s.line_end],
                 }),
-                SymbolChange::Modified { old, new, signature_changed } => serde_json::json!({
+                SymbolChange::Modified {
+                    old,
+                    new,
+                    signature_changed,
+                } => serde_json::json!({
                     "file": fd.path,
                     "symbol": new.qualified_name,
                     "kind": format!("{:?}", new.kind),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -40,15 +40,12 @@ pub fn node_to_item(
         content,
         signature,
         body: None,
+        doc_comment: None,
         line_mappings: None,
     }
 }
 
-fn child_to_item(
-    child: &ChildSymbol,
-    source: &str,
-    handler: &dyn LanguageHandler,
-) -> Item {
+fn child_to_item(child: &ChildSymbol, source: &str, handler: &dyn LanguageHandler) -> Item {
     let vis = handler.member_visibility(child.node, source);
     let start = child.node.start_byte();
     let end = child.node.end_byte();
@@ -67,6 +64,7 @@ fn child_to_item(
         content,
         signature,
         body: None,
+        doc_comment: None,
         line_mappings: None,
     }
 }
@@ -124,12 +122,13 @@ pub fn list_symbols(
 
         // Deduplicate by name node position
         if let Some(ni) = name_idx
-            && let Some(nc) = m.captures.iter().find(|c| c.index == ni) {
-                let name_range = (nc.node.start_byte(), nc.node.end_byte());
-                if !seen_names.insert(name_range) {
-                    continue;
-                }
+            && let Some(nc) = m.captures.iter().find(|c| c.index == ni)
+        {
+            let name_range = (nc.node.start_byte(), nc.node.end_byte());
+            if !seen_names.insert(name_range) {
+                continue;
             }
+        }
 
         let info = match handler.classify_node(item_node, source) {
             Some(i) => i,
@@ -141,9 +140,25 @@ pub fn list_symbols(
         }
 
         let vis = handler.visibility(item_node, source);
-        items.push(node_to_item(item_node, source, handler, info.kind.clone(), info.name.clone(), vis));
+        items.push(node_to_item(
+            item_node,
+            source,
+            handler,
+            info.kind.clone(),
+            info.name.clone(),
+            vis,
+        ));
 
-        if depth >= 2 && matches!(info.kind, ItemKind::Class | ItemKind::Trait | ItemKind::Enum | ItemKind::Impl | ItemKind::Struct) {
+        if depth >= 2
+            && matches!(
+                info.kind,
+                ItemKind::Class
+                    | ItemKind::Trait
+                    | ItemKind::Enum
+                    | ItemKind::Impl
+                    | ItemKind::Struct
+            )
+        {
             let inner = unwrap_export(item_node, source);
             for child in &handler.child_symbols(inner, source) {
                 items.push(child_to_item(child, source, handler));
@@ -178,9 +193,10 @@ pub fn find_symbol_node_by_query<'a>(
             None => continue,
         };
         if let Some(nc) = m.captures.iter().find(|c| c.index == name_idx)
-            && &source[nc.node.byte_range()] == name {
-                return Some(item_cap.node);
-            }
+            && &source[nc.node.byte_range()] == name
+        {
+            return Some(item_cap.node);
+        }
     }
     None
 }
@@ -219,9 +235,10 @@ fn find_all_symbol_nodes_by_query<'a>(
             None => continue,
         };
         if let Some(nc) = m.captures.iter().find(|c| c.index == name_idx)
-            && &source[nc.node.byte_range()] == name {
-                results.push(item_cap.node);
-            }
+            && &source[nc.node.byte_range()] == name
+        {
+            results.push(item_cap.node);
+        }
     }
     results
 }
@@ -251,7 +268,9 @@ pub fn expand_symbol(
     if parts.len() == 1 {
         let info = handler.classify_node(root_node, source)?;
         let vis = handler.visibility(root_node, source);
-        return Some(vec![node_to_item(root_node, source, handler, info.kind, info.name, vis)]);
+        return Some(vec![node_to_item(
+            root_node, source, handler, info.kind, info.name, vis,
+        )]);
     }
 
     let member_name = parts[parts.len() - 1];
@@ -305,19 +324,23 @@ pub fn find_unqualified_member(
 
         // Deduplicate by name node position
         if let Some(ni) = name_q_idx
-            && let Some(nc) = m.captures.iter().find(|c| c.index == ni) {
-                let nr = (nc.node.start_byte(), nc.node.end_byte());
-                if !seen_names.insert(nr) {
-                    continue;
-                }
+            && let Some(nc) = m.captures.iter().find(|c| c.index == ni)
+        {
+            let nr = (nc.node.start_byte(), nc.node.end_byte());
+            if !seen_names.insert(nr) {
+                continue;
             }
+        }
 
         let info = match handler.classify_node(item_node, source) {
             Some(i) => i,
             None => continue,
         };
 
-        if !matches!(info.kind, ItemKind::Class | ItemKind::Trait | ItemKind::Enum | ItemKind::Impl | ItemKind::Struct) {
+        if !matches!(
+            info.kind,
+            ItemKind::Class | ItemKind::Trait | ItemKind::Enum | ItemKind::Impl | ItemKind::Struct
+        ) {
             continue;
         }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,9 +1,9 @@
 use crate::error::CodehudError;
 use crate::extractor::find_attr_start;
-use crate::languages::{ts_language, Language};
+use crate::languages::{Language, ts_language};
 use crate::parser;
-use tree_sitter::{Node, Tree};
 use tree_sitter::StreamingIterator;
+use tree_sitter::{Node, Tree};
 
 /// Replace an entire symbol (including attributes) with new content.
 /// Returns the modified source code.
@@ -15,43 +15,39 @@ pub fn replace(
 ) -> Result<String, CodehudError> {
     let tree = parser::parse(source, language)?;
     let (start_byte, end_byte) = find_symbol_range(source, &tree, symbol_name, language)?;
-    
+
     // Build the new source
     let mut result = String::new();
     result.push_str(&source[..start_byte]);
     result.push_str(new_content);
     result.push_str(&source[end_byte..]);
-    
+
     // Validate by re-parsing
     validate_result(&result, language)?;
-    
+
     Ok(result)
 }
 
 /// Delete a symbol (including attributes).
 /// Returns the modified source code.
-pub fn delete(
-    source: &str,
-    symbol_name: &str,
-    language: Language,
-) -> Result<String, CodehudError> {
+pub fn delete(source: &str, symbol_name: &str, language: Language) -> Result<String, CodehudError> {
     let tree = parser::parse(source, language)?;
     let (start_byte, end_byte) = find_symbol_range(source, &tree, symbol_name, language)?;
-    
+
     // Find if there's a trailing newline to remove
     let mut effective_end = end_byte;
     if end_byte < source.len() && source.as_bytes()[end_byte] == b'\n' {
         effective_end = end_byte + 1;
     }
-    
+
     // Build the new source
     let mut result = String::new();
     result.push_str(&source[..start_byte]);
     result.push_str(&source[effective_end..]);
-    
+
     // Validate by re-parsing
     validate_result(&result, language)?;
-    
+
     Ok(result)
 }
 
@@ -66,18 +62,18 @@ pub fn replace_body(
 ) -> Result<String, CodehudError> {
     let tree = parser::parse(source, language)?;
     let item_node = find_symbol_node(source, &tree, symbol_name, language)?;
-    
+
     let body_node = find_body_node(item_node, language)?;
     let body_start = body_node.start_byte();
     let body_end = body_node.end_byte();
-    
+
     // Detect indent level of the body's opening brace line
     let line_start = source[..body_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
     let original_indent = &source[line_start..body_start]
         .chars()
         .take_while(|c| c.is_whitespace())
         .collect::<String>();
-    
+
     // Build the new body block with proper indentation
     let reindented = reindent_body(new_body, original_indent);
     let new_block = if language.uses_braces_for_blocks() {
@@ -85,12 +81,12 @@ pub fn replace_body(
     } else {
         format!("\n{}", reindented)
     };
-    
+
     let mut result = String::new();
     result.push_str(&source[..body_start]);
     result.push_str(&new_block);
     result.push_str(&source[body_end..]);
-    
+
     validate_result(&result, language)?;
     Ok(result)
 }
@@ -105,32 +101,38 @@ pub fn batch(
     // Resolve all byte ranges first, before any mutations
     let tree = parser::parse(source, language)?;
     let mut resolved: Vec<ResolvedEdit> = Vec::new();
-    
+
     // Separate add-type operations (applied sequentially after byte-range edits)
     let mut deferred_adds: Vec<&BatchEdit> = Vec::new();
-    
+
     for edit in edits {
         match edit.action {
             BatchAction::Replace => {
                 let content = edit.content.as_deref().ok_or_else(|| {
                     CodehudError::ParseError(format!(
-                        "Missing 'content' for replace action on '{}'", edit.symbol
+                        "Missing 'content' for replace action on '{}'",
+                        edit.symbol
                     ))
                 })?;
                 let (start, end) = find_symbol_range(source, &tree, &edit.symbol, language)?;
-                resolved.push(ResolvedEdit { start, end, replacement: content.to_string() });
+                resolved.push(ResolvedEdit {
+                    start,
+                    end,
+                    replacement: content.to_string(),
+                });
             }
             BatchAction::ReplaceBody => {
                 let content = edit.content.as_deref().ok_or_else(|| {
                     CodehudError::ParseError(format!(
-                        "Missing 'content' for replace-body action on '{}'", edit.symbol
+                        "Missing 'content' for replace-body action on '{}'",
+                        edit.symbol
                     ))
                 })?;
                 let item_node = find_symbol_node(source, &tree, &edit.symbol, language)?;
                 let body_node = find_body_node(item_node, language)?;
                 let body_start = body_node.start_byte();
                 let body_end = body_node.end_byte();
-                
+
                 let line_start = source[..body_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
                 let original_indent = &source[line_start..body_start]
                     .chars()
@@ -138,8 +140,12 @@ pub fn batch(
                     .collect::<String>();
                 let reindented = reindent_body(content, original_indent);
                 let new_block = format!("{{\n{}\n{}}}", reindented, original_indent);
-                
-                resolved.push(ResolvedEdit { start: body_start, end: body_end, replacement: new_block });
+
+                resolved.push(ResolvedEdit {
+                    start: body_start,
+                    end: body_end,
+                    replacement: new_block,
+                });
             }
             BatchAction::Delete => {
                 let (start, end) = find_symbol_range(source, &tree, &edit.symbol, language)?;
@@ -147,37 +153,50 @@ pub fn batch(
                 if effective_end < source.len() && source.as_bytes()[effective_end] == b'\n' {
                     effective_end += 1;
                 }
-                resolved.push(ResolvedEdit { start, end: effective_end, replacement: String::new() });
+                resolved.push(ResolvedEdit {
+                    start,
+                    end: effective_end,
+                    replacement: String::new(),
+                });
             }
-            BatchAction::AddAfter | BatchAction::AddBefore | BatchAction::Append | BatchAction::Prepend => {
+            BatchAction::AddAfter
+            | BatchAction::AddBefore
+            | BatchAction::Append
+            | BatchAction::Prepend => {
                 deferred_adds.push(edit);
             }
         }
     }
-    
+
     // Sort by start byte descending (bottom-to-top) so earlier offsets stay valid
     resolved.sort_by(|a, b| b.start.cmp(&a.start));
-    
+
     // Check for overlapping ranges
     for w in resolved.windows(2) {
         // w[0] has higher start than w[1] (sorted descending)
         if w[1].end > w[0].start {
             return Err(CodehudError::ParseError(
-                "Overlapping edit ranges detected".to_string()
+                "Overlapping edit ranges detected".to_string(),
             ));
         }
     }
-    
+
     let mut result = source.to_string();
     for edit in &resolved {
-        result = format!("{}{}{}", &result[..edit.start], edit.replacement, &result[edit.end..]);
+        result = format!(
+            "{}{}{}",
+            &result[..edit.start],
+            edit.replacement,
+            &result[edit.end..]
+        );
     }
-    
+
     // Apply deferred add operations sequentially (each re-parses)
     for add_edit in &deferred_adds {
         let content = add_edit.content.as_deref().ok_or_else(|| {
             CodehudError::ParseError(format!(
-                "Missing 'content' for {:?} action on '{}'", add_edit.action, add_edit.symbol
+                "Missing 'content' for {:?} action on '{}'",
+                add_edit.action, add_edit.symbol
             ))
         })?;
         result = match add_edit.action {
@@ -188,7 +207,7 @@ pub fn batch(
             _ => unreachable!(),
         };
     }
-    
+
     if deferred_adds.is_empty() {
         validate_result(&result, language)?;
     }
@@ -206,12 +225,13 @@ pub fn add_after(
     let tree = parser::parse(source, language)?;
     let node = find_symbol_node(source, &tree, symbol_name, language)?;
     let end_byte = node.end_byte();
-    
+
     // Find end of line after the symbol
-    let insert_pos = source[end_byte..].find('\n')
+    let insert_pos = source[end_byte..]
+        .find('\n')
         .map(|i| end_byte + i + 1)
         .unwrap_or(source.len());
-    
+
     // Detect indentation of the reference symbol
     let (attr_start, _) = find_attr_start(node);
     let line_start = source[..attr_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
@@ -219,9 +239,9 @@ pub fn add_after(
         .chars()
         .take_while(|c| c.is_whitespace())
         .collect();
-    
+
     let reindented = reindent_to_level(new_content, &indent);
-    
+
     let mut result = String::new();
     result.push_str(&source[..insert_pos]);
     result.push('\n');
@@ -230,7 +250,7 @@ pub fn add_after(
         result.push('\n');
     }
     result.push_str(&source[insert_pos..]);
-    
+
     validate_result(&result, language)?;
     Ok(result)
 }
@@ -246,16 +266,16 @@ pub fn add_before(
     let tree = parser::parse(source, language)?;
     let node = find_symbol_node(source, &tree, symbol_name, language)?;
     let (attr_start, _) = find_attr_start(node);
-    
+
     // Find start of line for the symbol (or its attribute)
     let line_start = source[..attr_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
     let indent: String = source[line_start..attr_start]
         .chars()
         .take_while(|c| c.is_whitespace())
         .collect();
-    
+
     let reindented = reindent_to_level(new_content, &indent);
-    
+
     let mut result = String::new();
     result.push_str(&source[..line_start]);
     result.push_str(&reindented);
@@ -264,18 +284,14 @@ pub fn add_before(
     }
     result.push('\n');
     result.push_str(&source[line_start..]);
-    
+
     validate_result(&result, language)?;
     Ok(result)
 }
 
 /// Append new code to end of file.
 /// Returns the modified source code.
-pub fn append(
-    source: &str,
-    new_content: &str,
-    language: Language,
-) -> Result<String, CodehudError> {
+pub fn append(source: &str, new_content: &str, language: Language) -> Result<String, CodehudError> {
     let mut result = source.to_string();
     if !result.ends_with('\n') && !result.is_empty() {
         result.push('\n');
@@ -287,7 +303,7 @@ pub fn append(
     if !result.ends_with('\n') {
         result.push('\n');
     }
-    
+
     validate_result(&result, language)?;
     Ok(result)
 }
@@ -302,13 +318,16 @@ pub fn prepend(
     // Find insertion point: skip leading comments, shebangs, and blank lines
     let tree = parser::parse(source, language)?;
     let root = tree.root_node();
-    
+
     let mut insert_byte = 0;
     let mut cursor = root.walk();
     for child in root.children(&mut cursor) {
         let kind = child.kind();
-        if kind == "line_comment" || kind == "block_comment" || kind == "comment"
-            || kind == "shebang" || kind == "hash_bang_line"
+        if kind == "line_comment"
+            || kind == "block_comment"
+            || kind == "comment"
+            || kind == "shebang"
+            || kind == "hash_bang_line"
             || kind.starts_with("attribute")
         {
             insert_byte = child.end_byte();
@@ -320,7 +339,7 @@ pub fn prepend(
             break;
         }
     }
-    
+
     let mut result = String::new();
     result.push_str(&source[..insert_byte]);
     if insert_byte > 0 && !source[..insert_byte].ends_with('\n') {
@@ -334,7 +353,7 @@ pub fn prepend(
         result.push('\n');
     }
     result.push_str(&source[insert_byte..]);
-    
+
     validate_result(&result, language)?;
     Ok(result)
 }
@@ -391,19 +410,34 @@ struct ResolvedEdit {
 fn find_body_node<'a>(item_node: Node<'a>, language: Language) -> Result<Node<'a>, CodehudError> {
     let body_kinds: &[&str] = match language {
         Language::Rust | Language::Python | Language::Go => &["block"],
-        Language::TypeScript | Language::Tsx | Language::JavaScript | Language::Jsx => &["statement_block"],
-        Language::Java => &["block", "class_body", "interface_body", "enum_body", "constructor_body", "annotation_type_body"],
+        Language::TypeScript | Language::Tsx | Language::JavaScript | Language::Jsx => {
+            &["statement_block"]
+        }
+        Language::Java => &[
+            "block",
+            "class_body",
+            "interface_body",
+            "enum_body",
+            "constructor_body",
+            "annotation_type_body",
+        ],
         Language::Cpp => &["compound_statement"],
         Language::CSharp => &["block", "declaration_list", "enum_member_declaration_list"],
-        Language::Kotlin => &["function_body", "class_body", "enum_class_body", "statements"],
+        Language::Kotlin => &[
+            "function_body",
+            "class_body",
+            "enum_class_body",
+            "statements",
+        ],
     };
-    
+
     // First try the `body` field (works for functions)
     if let Some(body) = item_node.child_by_field_name("body")
-        && body_kinds.contains(&body.kind()) {
-            return Ok(body);
-        }
-    
+        && body_kinds.contains(&body.kind())
+    {
+        return Ok(body);
+    }
+
     // Fallback: search children for a matching block kind
     let mut cursor = item_node.walk();
     for child in item_node.children(&mut cursor) {
@@ -411,26 +445,33 @@ fn find_body_node<'a>(item_node: Node<'a>, language: Language) -> Result<Node<'a
             return Ok(child);
         }
     }
-    
+
     Err(CodehudError::ParseError(format!(
-        "Symbol has no body block (kind: {})", item_node.kind()
+        "Symbol has no body block (kind: {})",
+        item_node.kind()
     )))
 }
 
 /// Re-indent content to a target indent level (no extra nesting).
 fn reindent_to_level(content: &str, target_indent: &str) -> String {
-    let min_indent = content.lines()
+    let min_indent = content
+        .lines()
         .filter(|l| !l.trim().is_empty())
         .map(|l| l.len() - l.trim_start().len())
         .min()
         .unwrap_or(0);
-    
-    content.lines()
+
+    content
+        .lines()
         .map(|line| {
             if line.trim().is_empty() {
                 String::new()
             } else {
-                let stripped = if line.len() >= min_indent { &line[min_indent..] } else { line.trim_start() };
+                let stripped = if line.len() >= min_indent {
+                    &line[min_indent..]
+                } else {
+                    line.trim_start()
+                };
                 format!("{}{}", target_indent, stripped)
             }
         })
@@ -442,20 +483,25 @@ fn reindent_to_level(content: &str, target_indent: &str) -> String {
 /// Each non-empty line gets `base_indent + one level (4 spaces)`.
 fn reindent_body(body: &str, base_indent: &str) -> String {
     let inner_indent = format!("{}    ", base_indent);
-    
+
     // Detect the minimum indent of the input to strip it
-    let min_indent = body.lines()
+    let min_indent = body
+        .lines()
         .filter(|l| !l.trim().is_empty())
         .map(|l| l.len() - l.trim_start().len())
         .min()
         .unwrap_or(0);
-    
+
     body.lines()
         .map(|line| {
             if line.trim().is_empty() {
                 String::new()
             } else {
-                let stripped = if line.len() >= min_indent { &line[min_indent..] } else { line.trim_start() };
+                let stripped = if line.len() >= min_indent {
+                    &line[min_indent..]
+                } else {
+                    line.trim_start()
+                };
                 format!("{}{}", inner_indent, stripped)
             }
         })
@@ -476,16 +522,26 @@ fn find_symbol_node<'a>(
     // For qualified names, use dispatch to find the member node directly
     if is_qualified {
         if let Some(handler) = crate::handler::handler_for(language) {
-            let parts: Vec<&str> = symbol_name.split(['.', ':']).filter(|s| !s.is_empty()).collect();
+            let parts: Vec<&str> = symbol_name
+                .split(['.', ':'])
+                .filter(|s| !s.is_empty())
+                .collect();
             if parts.len() >= 2 {
                 let class_name = parts[0];
                 let member_name = parts[parts.len() - 1];
-                if let Some(root) = crate::dispatch::find_symbol_node_by_query(source, tree, handler.as_ref(), language, class_name) {
+                if let Some(root) = crate::dispatch::find_symbol_node_by_query(
+                    source,
+                    tree,
+                    handler.as_ref(),
+                    language,
+                    class_name,
+                ) {
                     // Unwrap export to get inner class
                     let mut walk = root.walk();
                     let inner = if root.kind() == "export_statement" {
-                        
-                        root.named_children(&mut walk).find(|c| c.kind() != "decorator").unwrap_or(root)
+                        root.named_children(&mut walk)
+                            .find(|c| c.kind() != "decorator")
+                            .unwrap_or(root)
                     } else {
                         root
                     };
@@ -497,7 +553,10 @@ fn find_symbol_node<'a>(
                 }
             }
         }
-        return Err(CodehudError::ParseError(format!("Symbol not found: {}", symbol_name)));
+        return Err(CodehudError::ParseError(format!(
+            "Symbol not found: {}",
+            symbol_name
+        )));
     }
 
     let handler_box = crate::handler::handler_for(language)
@@ -505,35 +564,43 @@ fn find_symbol_node<'a>(
     let ts_lang = ts_language(language);
     let query = tree_sitter::Query::new(&ts_lang, handler_box.symbol_query())
         .map_err(|e| CodehudError::ParseError(format!("Query compilation failed: {}", e)))?;
-    
+
     let mut cursor = tree_sitter::QueryCursor::new();
     let source_bytes = source.as_bytes();
-    
-    let item_idx = query.capture_index_for_name("item")
+
+    let item_idx = query
+        .capture_index_for_name("item")
         .ok_or_else(|| CodehudError::ParseError("Query missing 'item' capture".to_string()))?;
-    
+
     let mut matches_iter = cursor.matches(&query, tree.root_node(), source_bytes);
-    
+
     while let Some(m) = matches_iter.next() {
         let item_node = match m.captures.iter().find(|c| c.index == item_idx) {
             Some(c) => c.node,
             None => continue,
         };
-        
+
         let info = match handler_box.classify_node(item_node, source) {
             Some(i) => i,
             None => continue,
         };
-        
+
         if let Some(ref n) = info.name
-            && n == symbol_name {
-                return Ok(item_node);
-            }
+            && n == symbol_name
+        {
+            return Ok(item_node);
+        }
     }
 
     // Fallback: try unqualified member search via dispatch
     if let Some(handler) = crate::handler::handler_for(language) {
-        let items = crate::dispatch::find_unqualified_member(source, tree, handler.as_ref(), language, symbol_name);
+        let items = crate::dispatch::find_unqualified_member(
+            source,
+            tree,
+            handler.as_ref(),
+            language,
+            symbol_name,
+        );
         if !items.is_empty() {
             // We need the node, not an Item — re-search using dispatch
             let ts_lang_obj = ts_language(language);
@@ -553,12 +620,20 @@ fn find_symbol_node<'a>(
                             Some(i) => i,
                             None => continue,
                         };
-                        if !matches!(info.kind, crate::extractor::ItemKind::Class | crate::extractor::ItemKind::Trait | crate::extractor::ItemKind::Enum) {
+                        if !matches!(
+                            info.kind,
+                            crate::extractor::ItemKind::Class
+                                | crate::extractor::ItemKind::Trait
+                                | crate::extractor::ItemKind::Enum
+                        ) {
                             continue;
                         }
                         let mut wlk = item_node.walk();
                         let inner = if item_node.kind() == "export_statement" {
-                            item_node.named_children(&mut wlk).find(|ch| ch.kind() != "decorator").unwrap_or(item_node)
+                            item_node
+                                .named_children(&mut wlk)
+                                .find(|ch| ch.kind() != "decorator")
+                                .unwrap_or(item_node)
                         } else {
                             item_node
                         };
@@ -572,8 +647,11 @@ fn find_symbol_node<'a>(
             }
         }
     }
-    
-    Err(CodehudError::ParseError(format!("Symbol not found: {}", symbol_name)))
+
+    Err(CodehudError::ParseError(format!(
+        "Symbol not found: {}",
+        symbol_name
+    )))
 }
 
 /// Find the byte range of a symbol (including attributes).
@@ -595,7 +673,7 @@ fn validate_result(source: &str, language: Language) -> Result<(), CodehudError>
     let tree = parser::parse(source, language)?;
     if tree.root_node().has_error() {
         return Err(CodehudError::ParseError(
-            "Edit resulted in invalid syntax".to_string()
+            "Edit resulted in invalid syntax".to_string(),
         ));
     }
     Ok(())
@@ -604,7 +682,7 @@ fn validate_result(source: &str, language: Language) -> Result<(), CodehudError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_replace_function() {
         let source = r#"fn foo() {
@@ -618,13 +696,13 @@ fn bar() {
         let new_fn = r#"fn foo() {
     println!("new");
 }"#;
-        
+
         let result = replace(source, "foo", new_fn, Language::Rust).unwrap();
         assert!(result.contains(r#"println!("new")"#));
         assert!(result.contains(r#"println!("keep")"#));
         assert!(!result.contains(r#"println!("old")"#));
     }
-    
+
     #[test]
     fn test_delete_function() {
         let source = r#"fn foo() {
@@ -635,13 +713,13 @@ fn bar() {
     println!("keep me");
 }
 "#;
-        
+
         let result = delete(source, "foo", Language::Rust).unwrap();
         assert!(!result.contains("delete me"));
         assert!(result.contains("keep me"));
         assert!(!result.contains("fn foo()"));
     }
-    
+
     #[test]
     fn test_delete_struct() {
         let source = r#"struct Foo {
@@ -652,35 +730,35 @@ struct Bar {
     y: i32,
 }
 "#;
-        
+
         let result = delete(source, "Foo", Language::Rust).unwrap();
         assert!(!result.contains("struct Foo"));
         assert!(result.contains("struct Bar"));
     }
-    
+
     #[test]
     fn test_validation_catches_bad_replacement() {
         let source = "fn foo() {}\n";
         let bad_replacement = "fn foo() { {{{{{ }";
-        
+
         let result = replace(source, "foo", bad_replacement, Language::Rust);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid syntax"));
     }
-    
+
     #[test]
     fn test_symbol_not_found() {
         let source = "fn foo() {}\n";
-        
+
         let result = replace(source, "nonexistent", "fn bar() {}", Language::Rust);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Symbol not found"));
-        
+
         let result = delete(source, "nonexistent", Language::Rust);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Symbol not found"));
     }
-    
+
     #[test]
     fn test_replace_with_attributes() {
         let source = r#"#[inline]
@@ -693,14 +771,17 @@ fn foo() -> i32 {
 fn foo() -> i32 {
     43
 }"#;
-        
+
         let result = replace(source, "foo", new_fn, Language::Rust).unwrap();
         assert!(result.contains("43"));
         assert!(!result.contains("42"));
         // Should replace the entire thing including old attributes
-        assert_eq!(result.lines().filter(|l| l.contains("#[must_use]")).count(), 0);
+        assert_eq!(
+            result.lines().filter(|l| l.contains("#[must_use]")).count(),
+            0
+        );
     }
-    
+
     #[test]
     fn test_replace_body_function() {
         let source = r#"fn foo(x: i32) -> i32 {
@@ -715,7 +796,7 @@ fn bar() {}
         assert!(!result.contains("x + 1"));
         assert!(result.contains("fn bar()"));
     }
-    
+
     #[test]
     fn test_replace_body_preserves_attributes() {
         let source = r#"#[inline]
@@ -729,16 +810,17 @@ pub fn foo() -> i32 {
         assert!(result.contains("99"));
         assert!(!result.contains("42"));
     }
-    
+
     #[test]
     fn test_replace_body_reindents() {
         let source = "    fn foo() {\n        old_code();\n    }\n";
         // Providing body with no indent — should get auto-indented
-        let result = replace_body(source, "foo", "new_code();\nmore_code();", Language::Rust).unwrap();
+        let result =
+            replace_body(source, "foo", "new_code();\nmore_code();", Language::Rust).unwrap();
         assert!(result.contains("        new_code();"));
         assert!(result.contains("        more_code();"));
     }
-    
+
     #[test]
     fn test_replace_body_no_body_errors() {
         let source = "struct Foo { x: i32 }\n";
@@ -747,7 +829,7 @@ pub fn foo() -> i32 {
         let result = replace_body(source, "Foo", "y: i32", Language::Rust);
         assert!(result.is_err());
     }
-    
+
     #[test]
     fn test_batch_multiple_edits() {
         let source = r#"fn foo() {
@@ -763,8 +845,16 @@ fn baz() {
 }
 "#;
         let edits = vec![
-            BatchEdit { symbol: "foo".to_string(), action: BatchAction::ReplaceBody, content: Some("new_foo();".to_string()) },
-            BatchEdit { symbol: "baz".to_string(), action: BatchAction::Delete, content: None },
+            BatchEdit {
+                symbol: "foo".to_string(),
+                action: BatchAction::ReplaceBody,
+                content: Some("new_foo();".to_string()),
+            },
+            BatchEdit {
+                symbol: "baz".to_string(),
+                action: BatchAction::Delete,
+                content: None,
+            },
         ];
         let result = batch(source, &edits, Language::Rust).unwrap();
         assert!(result.contains("new_foo()"));
@@ -772,7 +862,7 @@ fn baz() {
         assert!(result.contains("old_bar")); // bar untouched
         assert!(!result.contains("baz"));
     }
-    
+
     #[test]
     fn test_batch_replace_and_replace_body() {
         let source = r#"fn alpha() {
@@ -784,8 +874,16 @@ fn beta() {
 }
 "#;
         let edits = vec![
-            BatchEdit { symbol: "alpha".to_string(), action: BatchAction::Replace, content: Some("fn alpha() {\n    100\n}".to_string()) },
-            BatchEdit { symbol: "beta".to_string(), action: BatchAction::ReplaceBody, content: Some("200".to_string()) },
+            BatchEdit {
+                symbol: "alpha".to_string(),
+                action: BatchAction::Replace,
+                content: Some("fn alpha() {\n    100\n}".to_string()),
+            },
+            BatchEdit {
+                symbol: "beta".to_string(),
+                action: BatchAction::ReplaceBody,
+                content: Some("200".to_string()),
+            },
         ];
         let result = batch(source, &edits, Language::Rust).unwrap();
         assert!(result.contains("100"));
@@ -801,7 +899,7 @@ fn test_foo() {
 
 fn bar() {}
 "#;
-        
+
         let result = delete(source, "test_foo", Language::Rust).unwrap();
         assert!(!result.contains("test_foo"));
         assert!(!result.contains("#[test]"));
@@ -982,9 +1080,11 @@ fn bar() {}
     #[test]
     fn test_batch_with_add_after() {
         let source = "fn foo() {\n    1\n}\n\nfn bar() {\n    2\n}\n";
-        let edits = vec![
-            BatchEdit { symbol: "foo".to_string(), action: BatchAction::AddAfter, content: Some("fn baz() {\n    3\n}".to_string()) },
-        ];
+        let edits = vec![BatchEdit {
+            symbol: "foo".to_string(),
+            action: BatchAction::AddAfter,
+            content: Some("fn baz() {\n    3\n}".to_string()),
+        }];
         let result = batch(source, &edits, Language::Rust).unwrap();
         let foo_pos = result.find("fn foo()").unwrap();
         let baz_pos = result.find("fn baz()").unwrap();
@@ -996,9 +1096,11 @@ fn bar() {}
     #[test]
     fn test_batch_with_append() {
         let source = "fn foo() {\n    1\n}\n";
-        let edits = vec![
-            BatchEdit { symbol: String::new(), action: BatchAction::Append, content: Some("fn bar() {\n    2\n}".to_string()) },
-        ];
+        let edits = vec![BatchEdit {
+            symbol: String::new(),
+            action: BatchAction::Append,
+            content: Some("fn bar() {\n    2\n}".to_string()),
+        }];
         let result = batch(source, &edits, Language::Rust).unwrap();
         assert!(result.contains("fn bar()"));
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,34 +4,31 @@ use thiserror::Error;
 pub enum CodehudError {
     #[error("Path not found: {0}")]
     PathNotFound(String),
-    
+
     #[error("Invalid path: {0}")]
     InvalidPath(String),
-    
+
     #[error("Unsupported file extension: {0}")]
     UnsupportedExtension(String),
-    
+
     #[error("No file extension found for path: {0}")]
     NoExtension(String),
-    
+
     #[error("Failed to read {path}: {source}")]
     ReadError {
         path: String,
         #[source]
         source: std::io::Error,
     },
-    
+
     #[error("Parse error: {0}")]
     ParseError(String),
-    
+
     #[error("Serialization error")]
     SerializationError(#[from] serde_json::Error),
 
     #[error("symbol '{symbols}' not found in {path}")]
-    SymbolNotFound {
-        symbols: String,
-        path: String,
-    },
+    SymbolNotFound { symbols: String, path: String },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -46,10 +43,7 @@ pub enum CodehudError {
     HomeDir,
 
     #[error("Unknown platform '{platform}'. Available platforms: {available}")]
-    UnknownPlatform {
-        platform: String,
-        available: String,
-    },
+    UnknownPlatform { platform: String, available: String },
 
     #[error("{0} adapter not yet implemented")]
     NotImplemented(String),

--- a/src/extractor/collapse.rs
+++ b/src/extractor/collapse.rs
@@ -30,12 +30,21 @@ pub fn collapse_body(
 
 /// Collapse all function bodies inside an impl/trait block.
 /// Preserves the block structure but replaces each fn body with `{ ... }`.
-pub fn collapse_block(source: &str, start_byte: usize, block_node: Node) -> (String, Vec<(usize, String)>) {
+pub fn collapse_block(
+    source: &str,
+    start_byte: usize,
+    block_node: Node,
+) -> (String, Vec<(usize, String)>) {
     collapse_block_filtered(source, start_byte, block_node, &[])
 }
 
 /// Collapse a block, excluding specified byte ranges entirely (e.g., private members).
-pub fn collapse_block_filtered(source: &str, start_byte: usize, block_node: Node, exclude_ranges: &[(usize, usize)]) -> (String, Vec<(usize, String)>) {
+pub fn collapse_block_filtered(
+    source: &str,
+    start_byte: usize,
+    block_node: Node,
+    exclude_ranges: &[(usize, usize)],
+) -> (String, Vec<(usize, String)>) {
     // Collect function body ranges
     let mut body_ranges: Vec<(usize, usize)> = Vec::new();
     collect_fn_bodies(block_node, &mut body_ranges);
@@ -43,7 +52,10 @@ pub fn collapse_block_filtered(source: &str, start_byte: usize, block_node: Node
 
     // Build a unified list of skip actions sorted by position
     #[derive(Clone, Copy)]
-    enum SkipKind { CollapseBody, Exclude }
+    enum SkipKind {
+        CollapseBody,
+        Exclude,
+    }
     let mut skips: Vec<(usize, usize, SkipKind)> = Vec::new();
     for &(s, e) in &body_ranges {
         // Only add body collapse if not inside an excluded range
@@ -61,7 +73,9 @@ pub fn collapse_block_filtered(source: &str, start_byte: usize, block_node: Node
     let mut pos = start_byte;
 
     for (skip_start, skip_end, kind) in &skips {
-        if *skip_start < pos { continue; }
+        if *skip_start < pos {
+            continue;
+        }
         result.push_str(&source[pos..*skip_start]);
         match kind {
             SkipKind::CollapseBody => result.push_str("{ ... }"),
@@ -77,7 +91,8 @@ pub fn collapse_block_filtered(source: &str, start_byte: usize, block_node: Node
     }
 
     let start_line = source[..start_byte].matches('\n').count() + 1;
-    let mappings = build_collapsed_block_mappings(source, end_byte, &body_ranges, start_line, &result);
+    let mappings =
+        build_collapsed_block_mappings(source, end_byte, &body_ranges, start_line, &result);
 
     (result, mappings)
 }
@@ -90,7 +105,14 @@ fn collect_fn_bodies(node: Node, ranges: &mut Vec<(usize, usize)>) {
             if let Some(body) = child.child_by_field_name("body") {
                 ranges.push((body.start_byte(), body.end_byte()));
             }
-        } else if child.kind() == "declaration_list" || child.kind() == "class_body" || child.kind() == "interface_body" || child.kind() == "class_declaration" || child.kind() == "abstract_class_declaration" || child.kind() == "interface_declaration" || child.kind() == "export_statement" {
+        } else if child.kind() == "declaration_list"
+            || child.kind() == "class_body"
+            || child.kind() == "interface_body"
+            || child.kind() == "class_declaration"
+            || child.kind() == "abstract_class_declaration"
+            || child.kind() == "interface_declaration"
+            || child.kind() == "export_statement"
+        {
             // Recurse into block containers
             collect_fn_bodies(child, ranges);
         }
@@ -143,7 +165,10 @@ fn build_collapsed_block_mappings(
             surviving_source_lines.push(src_line);
             // Skip to after the body end line
             src_line = range.1 + 1;
-        } else if body_line_ranges.iter().any(|&(s, e)| src_line > s && src_line <= e) {
+        } else if body_line_ranges
+            .iter()
+            .any(|&(s, e)| src_line > s && src_line <= e)
+        {
             src_line += 1;
         } else {
             surviving_source_lines.push(src_line);
@@ -174,8 +199,6 @@ pub fn build_source_line_mappings(content: &str, start_line: usize) -> Vec<(usiz
         .map(|(i, line)| (start_line + i, line.to_string()))
         .collect()
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -238,7 +261,8 @@ mod tests {
         let item_start = source.find("fn").unwrap();
         let body_start = source.find('{').unwrap();
         let body_end = source.rfind('}').unwrap() + 1;
-        let (collapsed, mappings) = collapse_body(source, item_start, source.len(), body_start, body_end);
+        let (collapsed, mappings) =
+            collapse_body(source, item_start, source.len(), body_start, body_end);
         assert!(collapsed.contains("{ ... }"));
         assert_eq!(mappings[0].0, 2); // fn is on line 2
     }

--- a/src/extractor/expand.rs
+++ b/src/extractor/expand.rs
@@ -1,20 +1,24 @@
 use super::collapse::build_source_line_mappings;
-use super::{find_attr_start, Item, ItemKind};
+use super::{Item, ItemKind, find_attr_start};
 use crate::handler::{self, LanguageHandler};
-use crate::languages::{ts_language, Language};
+use crate::languages::{Language, ts_language};
 use tree_sitter::{Query, QueryCursor, StreamingIterator, Tree};
 
 /// Extract full implementation for specified symbols using tree-sitter queries.
 pub fn extract(source: &str, tree: &Tree, symbols: &[String], language: Language) -> Vec<Item> {
-    let handler = handler::handler_for(language)
-        .expect("all supported languages have handlers");
+    let handler = handler::handler_for(language).expect("all supported languages have handlers");
     extract_with_handler(source, tree, symbols, language, handler.as_ref())
 }
 
-fn extract_with_handler(source: &str, tree: &Tree, symbols: &[String], language: Language, handler: &dyn LanguageHandler) -> Vec<Item> {
+fn extract_with_handler(
+    source: &str,
+    tree: &Tree,
+    symbols: &[String],
+    language: Language,
+    handler: &dyn LanguageHandler,
+) -> Vec<Item> {
     let ts_lang = ts_language(language);
-    let query = Query::new(&ts_lang, handler.symbol_query())
-        .expect("symbol_query should compile");
+    let query = Query::new(&ts_lang, handler.symbol_query()).expect("symbol_query should compile");
 
     let mut cursor = QueryCursor::new();
     let source_bytes = source.as_bytes();
@@ -57,6 +61,7 @@ fn extract_with_handler(source: &str, tree: &Tree, symbols: &[String], language:
             signature: None,
             body: None,
             content,
+            doc_comment: None,
             line_mappings: None,
         });
     }
@@ -66,12 +71,16 @@ fn extract_with_handler(source: &str, tree: &Tree, symbols: &[String], language:
 }
 
 /// Extract a class with method signatures collapsed, optionally expanding specific methods.
-pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_methods: &[String], language: Language) -> Vec<Item> {
-    let handler = handler::handler_for(language)
-        .expect("all supported languages have handlers");
+pub fn extract_signatures(
+    source: &str,
+    tree: &Tree,
+    class_name: &str,
+    expand_methods: &[String],
+    language: Language,
+) -> Vec<Item> {
+    let handler = handler::handler_for(language).expect("all supported languages have handlers");
     let ts_lang = ts_language(language);
-    let query = Query::new(&ts_lang, handler.symbol_query())
-        .expect("symbol_query should compile");
+    let query = Query::new(&ts_lang, handler.symbol_query()).expect("symbol_query should compile");
 
     let mut cursor = QueryCursor::new();
     let source_bytes = source.as_bytes();
@@ -115,6 +124,7 @@ pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_me
                 signature: None,
                 body: None,
                 content,
+                doc_comment: None,
                 line_mappings: None,
             }];
         }
@@ -127,7 +137,8 @@ pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_me
         // Unwrap export wrapper to get the actual class node
         let mut walk = item_node.walk();
         let inner = if item_node.kind() == "export_statement" {
-            item_node.named_children(&mut walk)
+            item_node
+                .named_children(&mut walk)
                 .find(|c| c.kind() != "decorator")
                 .unwrap_or(item_node)
         } else {
@@ -139,9 +150,10 @@ pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_me
         for child in &children {
             // Skip children that are in the expand list
             if let Some(ref cname) = child.name
-                && expand_methods.iter().any(|m| m == cname) {
-                    continue;
-                }
+                && expand_methods.iter().any(|m| m == cname)
+            {
+                continue;
+            }
             // Only collapse nodes that have a body
             let body_field = handler.body_field_name();
             if let Some(body) = child.node.child_by_field_name(body_field) {
@@ -162,7 +174,11 @@ pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_me
         result.push_str(&source[pos..end_byte]);
 
         let mappings = super::collapse::build_collapsed_block_mappings_pub(
-            source, end_byte, &body_ranges, line_start, &result,
+            source,
+            end_byte,
+            &body_ranges,
+            line_start,
+            &result,
         );
 
         let line_mappings = if mappings.is_empty() {
@@ -179,6 +195,7 @@ pub fn extract_signatures(source: &str, tree: &Tree, class_name: &str, expand_me
             signature: None,
             body: None,
             content: result,
+            doc_comment: None,
             line_mappings,
         }];
     }

--- a/src/extractor/interface.rs
+++ b/src/extractor/interface.rs
@@ -1,22 +1,33 @@
-use super::collapse::{collapse_body, collapse_block, collapse_block_filtered, build_source_line_mappings};
+use super::collapse::{
+    build_source_line_mappings, collapse_block, collapse_block_filtered, collapse_body,
+};
+use super::{Item, find_attr_start};
 use super::{ItemKind, Visibility};
-use super::{find_attr_start, Item};
 use crate::handler::{self, LanguageHandler};
-use crate::languages::{ts_language, Language};
-use tree_sitter::{Query, QueryCursor, StreamingIterator, Tree};
+use crate::languages::{Language, ts_language};
 use std::collections::BTreeMap;
+use tree_sitter::{Query, QueryCursor, StreamingIterator, Tree};
 
 /// Extract interface view, optionally filtering private members from class bodies.
-pub fn extract_filtered(source: &str, tree: &Tree, language: Language, pub_only: bool) -> Vec<Item> {
-    let handler = handler::handler_for(language)
-        .expect("all supported languages have handlers");
+pub fn extract_filtered(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    pub_only: bool,
+) -> Vec<Item> {
+    let handler = handler::handler_for(language).expect("all supported languages have handlers");
     extract_with_handler(source, tree, language, handler.as_ref(), pub_only)
 }
 
-fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: &dyn LanguageHandler, pub_only: bool) -> Vec<Item> {
+fn extract_with_handler(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    handler: &dyn LanguageHandler,
+    pub_only: bool,
+) -> Vec<Item> {
     let ts_lang = ts_language(language);
-    let query = Query::new(&ts_lang, handler.symbol_query())
-        .expect("symbol_query should compile");
+    let query = Query::new(&ts_lang, handler.symbol_query()).expect("symbol_query should compile");
 
     let mut cursor = QueryCursor::new();
     // Limit to top-level (depth ≤ 3 handles export wrappers)
@@ -42,12 +53,13 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
 
         // Deduplicate by name node position
         if let Some(ni) = name_idx
-            && let Some(nc) = m.captures.iter().find(|c| c.index == ni) {
-                let name_range = (nc.node.start_byte(), nc.node.end_byte());
-                if !seen_names.insert(name_range) {
-                    continue;
-                }
+            && let Some(nc) = m.captures.iter().find(|c| c.index == ni)
+        {
+            let name_range = (nc.node.start_byte(), nc.node.end_byte());
+            if !seen_names.insert(name_range) {
+                continue;
             }
+        }
 
         let mut kind_str = item_node.kind();
         // For TS export_statement, use the inner declaration's kind
@@ -56,7 +68,12 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
             let mut c = item_node.walk();
             for child in item_node.children(&mut c) {
                 let ck = child.kind();
-                if ck != "export" && ck != ";" && ck != "default" && ck != "comment" && ck != "decorator" {
+                if ck != "export"
+                    && ck != ";"
+                    && ck != "default"
+                    && ck != "comment"
+                    && ck != "decorator"
+                {
                     inner = Some(child);
                     break;
                 }
@@ -87,13 +104,25 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
         let line_end = item_node.end_position().row + 1;
 
         let (content, line_mappings, has_body) = match kind_str {
-            "impl_item" | "trait_item" | "class_declaration" | "abstract_class_declaration" | "interface_declaration"
-            | "class_specifier" | "struct_specifier"
-            | "struct_declaration" | "record_declaration" | "enum_declaration" => {
-                let actual_node = if let Some(inner) = inner_node { inner } else { item_node };
+            "impl_item"
+            | "trait_item"
+            | "class_declaration"
+            | "abstract_class_declaration"
+            | "interface_declaration"
+            | "class_specifier"
+            | "struct_specifier"
+            | "struct_declaration"
+            | "record_declaration"
+            | "enum_declaration" => {
+                let actual_node = if let Some(inner) = inner_node {
+                    inner
+                } else {
+                    item_node
+                };
                 if pub_only {
                     let exclude = collect_private_member_ranges(actual_node, source, handler);
-                    let (c, m) = collapse_block_filtered(source, effective_start_byte, item_node, &exclude);
+                    let (c, m) =
+                        collapse_block_filtered(source, effective_start_byte, item_node, &exclude);
                     (c, m, false)
                 } else {
                     let (c, m) = collapse_block(source, effective_start_byte, item_node);
@@ -130,15 +159,34 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
             line_start,
             line_end,
             signature: None,
-            body: if has_body { Some("{ ... }".to_string()) } else { None },
+            body: if has_body {
+                Some("{ ... }".to_string())
+            } else {
+                None
+            },
             content: content.clone(),
+            doc_comment: None,
             line_mappings: line_mappings.clone(),
         });
 
-        if matches!(kind_str, "impl_item" | "trait_item" | "class_declaration" | "abstract_class_declaration"
-            | "class_specifier" | "struct_specifier"
-            | "struct_declaration" | "record_declaration" | "enum_declaration" | "interface_declaration") {
-            let block_node = if let Some(inner) = inner_node { inner } else { item_node };
+        if matches!(
+            kind_str,
+            "impl_item"
+                | "trait_item"
+                | "class_declaration"
+                | "abstract_class_declaration"
+                | "class_specifier"
+                | "struct_specifier"
+                | "struct_declaration"
+                | "record_declaration"
+                | "enum_declaration"
+                | "interface_declaration"
+        ) {
+            let block_node = if let Some(inner) = inner_node {
+                inner
+            } else {
+                item_node
+            };
             for child in handler.child_symbols(block_node, source) {
                 if !matches!(child.kind, ItemKind::Method | ItemKind::Function) {
                     continue;
@@ -146,7 +194,8 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
                 let vis = handler.member_visibility(child.node, source);
                 let child_line_start = child.node.start_position().row + 1;
                 let child_line_end = child.node.end_position().row + 1;
-                let child_content = source[child.node.start_byte()..child.node.end_byte()].to_string();
+                let child_content =
+                    source[child.node.start_byte()..child.node.end_byte()].to_string();
                 let signature = if matches!(child.kind, ItemKind::Method | ItemKind::Function) {
                     Some(handler.signature(child.node, source))
                 } else {
@@ -161,6 +210,7 @@ fn extract_with_handler(source: &str, tree: &Tree, language: Language, handler: 
                     signature,
                     body: None,
                     content: child_content,
+                    doc_comment: None,
                     line_mappings: None,
                 });
             }
@@ -184,8 +234,10 @@ fn collect_private_member_ranges(
     let mut cursor = body.walk();
     for child in body.children(&mut cursor) {
         let kind = child.kind();
-        if kind == "method_definition" || kind == "public_field_definition"
-            || kind == "property_definition" || kind == "abstract_method_signature"
+        if kind == "method_definition"
+            || kind == "public_field_definition"
+            || kind == "property_definition"
+            || kind == "abstract_method_signature"
             || kind == "function_item"
         {
             let vis = handler.member_visibility(child, source);

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,6 +1,6 @@
 pub mod collapse;
-pub mod interface;
 pub mod expand;
+pub mod interface;
 pub mod outline;
 
 use serde::Serialize;
@@ -15,6 +15,9 @@ pub struct Item {
     pub signature: Option<String>,
     pub body: Option<String>,
     pub content: String,
+    /// Doc comment attached to this symbol (populated when --with-comments is used)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc_comment: Option<String>,
     /// Explicit line mappings for content lines (line_num, text)
     /// Used when content has been modified (e.g., collapsed bodies)
     #[serde(skip)]
@@ -192,7 +195,6 @@ impl ItemKind {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Visibility {
@@ -224,11 +226,13 @@ pub fn find_attr_start(node: tree_sitter::Node) -> (usize, usize) {
     // parent export_statement has decorator children that precede this node
     if let Some(parent) = node.parent()
         && parent.kind() == "export_statement"
-            && let Some(first_child) = parent.child(0)
-                && first_child.kind() == "decorator" && first_child.start_byte() < start_byte {
-                    start_byte = first_child.start_byte();
-                    start_row = first_child.start_position().row;
-                }
+        && let Some(first_child) = parent.child(0)
+        && first_child.kind() == "decorator"
+        && first_child.start_byte() < start_byte
+    {
+        start_byte = first_child.start_byte();
+        start_row = first_child.start_position().row;
+    }
     (start_byte, start_row + 1)
 }
 
@@ -260,14 +264,11 @@ impl Visibility {
     }
 }
 
-
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::parse;
     use crate::languages::Language;
+    use crate::parser::parse;
 
     #[test]
     fn display_name_rust_uses_rust_terms() {
@@ -280,31 +281,49 @@ mod tests {
 
     #[test]
     fn display_name_typescript_uses_ts_terms() {
-        assert_eq!(ItemKind::Trait.display_name(Language::TypeScript), "interface");
+        assert_eq!(
+            ItemKind::Trait.display_name(Language::TypeScript),
+            "interface"
+        );
         assert_eq!(ItemKind::Use.display_name(Language::TypeScript), "import");
-        assert_eq!(ItemKind::TypeAlias.display_name(Language::TypeScript), "type alias");
+        assert_eq!(
+            ItemKind::TypeAlias.display_name(Language::TypeScript),
+            "type alias"
+        );
         assert_eq!(ItemKind::Mod.display_name(Language::TypeScript), "module");
-        assert_eq!(ItemKind::Struct.display_name(Language::TypeScript), "interface");
+        assert_eq!(
+            ItemKind::Struct.display_name(Language::TypeScript),
+            "interface"
+        );
     }
 
     #[test]
     fn display_name_tsx_same_as_typescript() {
         assert_eq!(ItemKind::Trait.display_name(Language::Tsx), "interface");
         assert_eq!(ItemKind::Use.display_name(Language::Tsx), "import");
-        assert_eq!(ItemKind::TypeAlias.display_name(Language::Tsx), "type alias");
+        assert_eq!(
+            ItemKind::TypeAlias.display_name(Language::Tsx),
+            "type alias"
+        );
     }
 
     #[test]
     fn display_name_python_uses_python_terms() {
         assert_eq!(ItemKind::Trait.display_name(Language::Python), "protocol");
         assert_eq!(ItemKind::Use.display_name(Language::Python), "import");
-        assert_eq!(ItemKind::TypeAlias.display_name(Language::Python), "TypeAlias");
+        assert_eq!(
+            ItemKind::TypeAlias.display_name(Language::Python),
+            "TypeAlias"
+        );
         assert_eq!(ItemKind::Struct.display_name(Language::Python), "class");
     }
 
     #[test]
     fn display_name_javascript_uses_js_terms() {
-        assert_eq!(ItemKind::Trait.display_name(Language::JavaScript), "interface");
+        assert_eq!(
+            ItemKind::Trait.display_name(Language::JavaScript),
+            "interface"
+        );
         assert_eq!(ItemKind::Use.display_name(Language::JavaScript), "import");
         assert_eq!(ItemKind::Mod.display_name(Language::JavaScript), "module");
     }
@@ -312,7 +331,12 @@ mod tests {
     #[test]
     fn display_name_shared_kinds_unchanged() {
         // These should be the same across all languages
-        for lang in [Language::Rust, Language::TypeScript, Language::Python, Language::JavaScript] {
+        for lang in [
+            Language::Rust,
+            Language::TypeScript,
+            Language::Python,
+            Language::JavaScript,
+        ] {
             assert_eq!(ItemKind::Function.display_name(lang), "fn");
             assert_eq!(ItemKind::Method.display_name(lang), "fn");
             assert_eq!(ItemKind::Enum.display_name(lang), "enum");

--- a/src/extractor/outline.rs
+++ b/src/extractor/outline.rs
@@ -3,17 +3,23 @@
 //! Middle ground between `--list-symbols` (one-liner per symbol) and full expand.
 //! Shows the shape of code with enough detail to understand the API.
 
-use super::{find_attr_start, Item, ItemKind, Visibility};
+use super::{Item, ItemKind, Visibility, find_attr_start};
 use crate::handler::{self, LanguageHandler};
-use crate::languages::{ts_language, Language};
-use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
+use crate::languages::{Language, ts_language};
 use std::collections::BTreeMap;
+use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
 
 /// Extract outline view: signatures + docstrings, no bodies.
-pub fn extract_outline(source: &str, tree: &Tree, language: Language, pub_only: bool, compact: bool) -> Vec<Item> {
-    let handler = handler::handler_for(language)
-        .expect("all supported languages have handlers");
-    let mut items = extract_outline_with_handler(source, tree, language, handler.as_ref(), pub_only);
+pub fn extract_outline(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    pub_only: bool,
+    compact: bool,
+) -> Vec<Item> {
+    let handler = handler::handler_for(language).expect("all supported languages have handlers");
+    let mut items =
+        extract_outline_with_handler(source, tree, language, handler.as_ref(), pub_only);
     if compact {
         for item in &mut items {
             item.content = compactify_item(item, source);
@@ -30,8 +36,7 @@ fn extract_outline_with_handler(
     pub_only: bool,
 ) -> Vec<Item> {
     let ts_lang = ts_language(language);
-    let query = Query::new(&ts_lang, handler.symbol_query())
-        .expect("symbol_query should compile");
+    let query = Query::new(&ts_lang, handler.symbol_query()).expect("symbol_query should compile");
 
     let mut cursor = QueryCursor::new();
     cursor.set_max_start_depth(Some(2));
@@ -54,12 +59,13 @@ fn extract_outline_with_handler(
 
         // Deduplicate by name node position
         if let Some(ni) = name_idx
-            && let Some(nc) = m.captures.iter().find(|c| c.index == ni) {
-                let name_range = (nc.node.start_byte(), nc.node.end_byte());
-                if !seen_names.insert(name_range) {
-                    continue;
-                }
+            && let Some(nc) = m.captures.iter().find(|c| c.index == ni)
+        {
+            let name_range = (nc.node.start_byte(), nc.node.end_byte());
+            if !seen_names.insert(name_range) {
+                continue;
             }
+        }
 
         let info = match handler.classify_node(item_node, source) {
             Some(i) => i,
@@ -91,6 +97,7 @@ fn extract_outline_with_handler(
                 signature: None,
                 body: None,
                 content,
+                doc_comment: None,
                 line_mappings: None,
             });
         } else if matches!(info.kind, ItemKind::Function | ItemKind::Method) {
@@ -111,6 +118,7 @@ fn extract_outline_with_handler(
                 signature: Some(sig),
                 body: None,
                 content,
+                doc_comment: None,
                 line_mappings: None,
             });
         } else if matches!(info.kind, ItemKind::Struct | ItemKind::Enum) {
@@ -132,9 +140,13 @@ fn extract_outline_with_handler(
                 signature: None,
                 body: None,
                 content,
+                doc_comment: None,
                 line_mappings: None,
             });
-        } else if matches!(info.kind, ItemKind::TypeAlias | ItemKind::Const | ItemKind::Static) {
+        } else if matches!(
+            info.kind,
+            ItemKind::TypeAlias | ItemKind::Const | ItemKind::Static
+        ) {
             // Type aliases, constants, statics: show as-is
             let (effective_start_byte, _) = find_attr_start(item_node);
             let text = &source[effective_start_byte..item_node.end_byte()];
@@ -153,6 +165,7 @@ fn extract_outline_with_handler(
                 signature: None,
                 body: None,
                 content,
+                doc_comment: None,
                 line_mappings: None,
             });
         } else if matches!(info.kind, ItemKind::Use) {
@@ -167,13 +180,15 @@ fn extract_outline_with_handler(
                 signature: None,
                 body: None,
                 content: text.to_string(),
+                doc_comment: None,
                 line_mappings: None,
             });
         } else if matches!(info.kind, ItemKind::Mod) {
             // Inline mod blocks: show as container if they have a body, otherwise as-is
             let has_body = item_node.child_by_field_name("body").is_some();
             if has_body {
-                let content = build_container_outline(source, item_node, handler, pub_only, language);
+                let content =
+                    build_container_outline(source, item_node, handler, pub_only, language);
                 items_map.entry(line_start).or_insert(Item {
                     kind: info.kind,
                     name: info.name,
@@ -183,6 +198,7 @@ fn extract_outline_with_handler(
                     signature: None,
                     body: None,
                     content,
+                    doc_comment: None,
                     line_mappings: None,
                 });
             } else {
@@ -197,6 +213,7 @@ fn extract_outline_with_handler(
                     signature: None,
                     body: None,
                     content: text.to_string(),
+                    doc_comment: None,
                     line_mappings: None,
                 });
             }
@@ -221,7 +238,8 @@ fn build_container_outline(
     // Get the container header (everything before the body block)
     let inner_node = if item_node.kind() == "export_statement" {
         let mut walk = item_node.walk();
-        item_node.named_children(&mut walk)
+        item_node
+            .named_children(&mut walk)
             .find(|c| c.kind() != "decorator" && c.kind() != "comment")
             .unwrap_or(item_node)
     } else {
@@ -301,9 +319,7 @@ fn compactify_item(item: &Item, _source: &str) -> String {
         ItemKind::Class | ItemKind::Impl | ItemKind::Trait | ItemKind::Mod => {
             compactify_container(&item.content)
         }
-        ItemKind::Function | ItemKind::Method => {
-            compact_signature(&item.content)
-        }
+        ItemKind::Function | ItemKind::Method => compact_signature(&item.content),
         ItemKind::Struct | ItemKind::Enum => {
             // Just the first line (type header)
             compact_type_header(&item.content)
@@ -319,10 +335,16 @@ fn compactify_item(item: &Item, _source: &str) -> String {
 fn compact_signature(content: &str) -> String {
     let lines: Vec<&str> = content.lines().collect();
     // Skip doc comment lines
-    let sig_lines: Vec<&str> = lines.iter().copied()
+    let sig_lines: Vec<&str> = lines
+        .iter()
+        .copied()
         .filter(|l| {
             let t = l.trim();
-            !(t.starts_with("///") || t.starts_with("/**") || t.starts_with("* ") || t.starts_with("*/") || t.starts_with("#"))
+            !(t.starts_with("///")
+                || t.starts_with("/**")
+                || t.starts_with("* ")
+                || t.starts_with("*/")
+                || t.starts_with("#"))
         })
         .collect();
     let sig = sig_lines.join("\n");
@@ -370,7 +392,11 @@ fn compactify_container(content: &str) -> String {
     for line in content.lines() {
         let trimmed = line.trim();
         // Skip doc comment lines
-        if trimmed.starts_with("///") || trimmed.starts_with("/**") || trimmed.starts_with("* ") || trimmed.starts_with("*/") {
+        if trimmed.starts_with("///")
+            || trimmed.starts_with("/**")
+            || trimmed.starts_with("* ")
+            || trimmed.starts_with("*/")
+        {
             in_doc = true;
             continue;
         }
@@ -382,7 +408,9 @@ fn compactify_container(content: &str) -> String {
         // Collapse params in member signatures
         let compacted = collapse_params(line);
         // Skip consecutive blank lines
-        if compacted.trim().is_empty() && result.last().is_some_and(|l: &String| l.trim().is_empty()) {
+        if compacted.trim().is_empty()
+            && result.last().is_some_and(|l: &String| l.trim().is_empty())
+        {
             continue;
         }
         result.push(compacted);
@@ -400,7 +428,11 @@ fn compact_type_header(content: &str) -> String {
     // Skip doc comments, find first non-doc line
     for line in &lines {
         let t = line.trim();
-        if t.starts_with("///") || t.starts_with("/**") || t.starts_with("* ") || t.starts_with("*/") {
+        if t.starts_with("///")
+            || t.starts_with("/**")
+            || t.starts_with("* ")
+            || t.starts_with("*/")
+        {
             continue;
         }
         // Return just this first real line + " { … }" if it has a body
@@ -451,13 +483,16 @@ fn get_docstring(source: &str, node: Node) -> Option<String> {
     comments.reverse();
 
     // Only include doc comments (/// or /** or #) not regular // comments
-    let doc_comments: Vec<&String> = comments.iter().filter(|c| {
-        let trimmed = c.trim();
-        trimmed.starts_with("///")
-            || trimmed.starts_with("/**")
-            || trimmed.starts_with("* ")
-            || trimmed.starts_with("#")  // Python docstrings via comment nodes
-    }).collect();
+    let doc_comments: Vec<&String> = comments
+        .iter()
+        .filter(|c| {
+            let trimmed = c.trim();
+            trimmed.starts_with("///")
+                || trimmed.starts_with("/**")
+                || trimmed.starts_with("* ")
+                || trimmed.starts_with("#") // Python docstrings via comment nodes
+        })
+        .collect();
 
     if doc_comments.is_empty() {
         // For TS/JS, also accept /** ... */ block comments
@@ -468,5 +503,11 @@ fn get_docstring(source: &str, node: Node) -> Option<String> {
         return None;
     }
 
-    Some(doc_comments.into_iter().cloned().collect::<Vec<_>>().join("\n"))
+    Some(
+        doc_comments
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -41,7 +41,10 @@ fn git(repo: &Path, args: &[&str]) -> Result<String, CodehudError> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(CodehudError::ParseError(format!("git error: {}", stderr.trim())));
+        return Err(CodehudError::ParseError(format!(
+            "git error: {}",
+            stderr.trim()
+        )));
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }

--- a/src/handler/cpp.rs
+++ b/src/handler/cpp.rs
@@ -393,8 +393,7 @@ fn cpp_child_symbols<'a>(node: Node<'a>, source: &str) -> Vec<ChildSymbol<'a>> {
                         }
                         "declaration" => {
                             let declarator = child.child_by_field_name("declarator");
-                            let name =
-                                declarator.and_then(|d| extract_declarator_name(d, source));
+                            let name = declarator.and_then(|d| extract_declarator_name(d, source));
                             let is_func = declarator
                                 .map(|d| d.kind() == "function_declarator")
                                 .unwrap_or(false);
@@ -411,8 +410,7 @@ fn cpp_child_symbols<'a>(node: Node<'a>, source: &str) -> Vec<ChildSymbol<'a>> {
                         }
                         "field_declaration" => {
                             let declarator = child.child_by_field_name("declarator");
-                            let name =
-                                declarator.and_then(|d| extract_declarator_name(d, source));
+                            let name = declarator.and_then(|d| extract_declarator_name(d, source));
                             let is_func = declarator
                                 .map(|d| d.kind() == "function_declarator")
                                 .unwrap_or(false);
@@ -538,15 +536,16 @@ fn parse_cpp_includes(
     let mut cursor = root.walk();
     for child in root.named_children(&mut cursor) {
         if child.kind() == "preproc_include"
-            && let Some(path_node) = child.child_by_field_name("path") {
-                let raw = source[path_node.byte_range()].to_string();
-                let clean = raw.trim_matches(|c| c == '"' || c == '<' || c == '>');
-                edges.push(crate::xrefs::ImportEdge {
-                    importing_file: file_path.to_path_buf(),
-                    source: clean.to_string(),
-                    symbols: vec![],
-                    resolved_path: None,
-                });
+            && let Some(path_node) = child.child_by_field_name("path")
+        {
+            let raw = source[path_node.byte_range()].to_string();
+            let clean = raw.trim_matches(|c| c == '"' || c == '<' || c == '>');
+            edges.push(crate::xrefs::ImportEdge {
+                importing_file: file_path.to_path_buf(),
+                source: clean.to_string(),
+                symbols: vec![],
+                resolved_path: None,
+            });
         }
     }
     edges
@@ -558,7 +557,9 @@ mod tests {
 
     fn parse_cpp(source: &str) -> tree_sitter::Tree {
         let mut parser = Parser::new();
-        parser.set_language(&tree_sitter_cpp::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_cpp::LANGUAGE.into())
+            .unwrap();
         parser.parse(source, None).unwrap()
     }
 
@@ -569,7 +570,15 @@ mod tests {
         let source = "class MyClass {\npublic:\n    void method() const {}\n};\n\nvoid free_function(int x) {}\n";
         let tree = parse_cpp(source);
         let items = extract_filtered(source, &tree, Language::Cpp, false);
-        assert!(items.iter().any(|i| i.name.as_deref() == Some("MyClass")), "should find MyClass");
-        assert!(items.iter().any(|i| i.name.as_deref() == Some("free_function")), "should find free_function");
+        assert!(
+            items.iter().any(|i| i.name.as_deref() == Some("MyClass")),
+            "should find MyClass"
+        );
+        assert!(
+            items
+                .iter()
+                .any(|i| i.name.as_deref() == Some("free_function")),
+            "should find free_function"
+        );
     }
 }

--- a/src/handler/csharp.rs
+++ b/src/handler/csharp.rs
@@ -113,10 +113,9 @@ impl LanguageHandler for CSharpHandler {
         let name = match node.kind() {
             "using_directive" => None,
             "field_declaration" => field_name(node, source),
-            "namespace_declaration" => {
-                node.child_by_field_name("name")
-                    .map(|n| source[n.byte_range()].to_string())
-            }
+            "namespace_declaration" => node
+                .child_by_field_name("name")
+                .map(|n| source[n.byte_range()].to_string()),
             _ => node
                 .child_by_field_name("name")
                 .map(|n| source[n.byte_range()].to_string()),
@@ -250,8 +249,9 @@ impl LanguageHandler for CSharpHandler {
 
         // Return type (for methods)
         if node.kind() == "method_declaration"
-            && let Some(ret) = node.child_by_field_name("type") {
-                parts.push(source[ret.byte_range()].to_string());
+            && let Some(ret) = node.child_by_field_name("type")
+        {
+            parts.push(source[ret.byte_range()].to_string());
         }
 
         // Name

--- a/src/handler/go.rs
+++ b/src/handler/go.rs
@@ -38,21 +38,30 @@ impl LanguageHandler for GoHandler {
     fn classify_node(&self, node: Node, source: &str) -> Option<SymbolInfo> {
         match node.kind() {
             "function_declaration" => {
-                let name = node.child_by_field_name("name")
+                let name = node
+                    .child_by_field_name("name")
                     .map(|n| source[n.byte_range()].to_string());
-                Some(SymbolInfo { kind: ItemKind::Function, name })
+                Some(SymbolInfo {
+                    kind: ItemKind::Function,
+                    name,
+                })
             }
             "method_declaration" => {
-                let name = node.child_by_field_name("name")
+                let name = node
+                    .child_by_field_name("name")
                     .map(|n| source[n.byte_range()].to_string());
-                Some(SymbolInfo { kind: ItemKind::Function, name })
+                Some(SymbolInfo {
+                    kind: ItemKind::Function,
+                    name,
+                })
             }
             "type_declaration" => {
                 // Find the type_spec child to get name and determine kind
                 let mut cursor = node.walk();
                 for child in node.named_children(&mut cursor) {
                     if child.kind() == "type_spec" {
-                        let name = child.child_by_field_name("name")
+                        let name = child
+                            .child_by_field_name("name")
                             .map(|n| source[n.byte_range()].to_string());
                         let type_node = child.child_by_field_name("type");
                         let kind = match type_node.map(|n| n.kind()) {
@@ -68,21 +77,32 @@ impl LanguageHandler for GoHandler {
             "const_declaration" => {
                 // Try to get the first const name
                 let name = extract_first_spec_name(node, source, "const_spec");
-                Some(SymbolInfo { kind: ItemKind::Const, name })
+                Some(SymbolInfo {
+                    kind: ItemKind::Const,
+                    name,
+                })
             }
             "var_declaration" => {
                 let name = extract_first_spec_name(node, source, "var_spec");
-                Some(SymbolInfo { kind: ItemKind::Static, name })
+                Some(SymbolInfo {
+                    kind: ItemKind::Static,
+                    name,
+                })
             }
-            "import_declaration" => {
-                Some(SymbolInfo { kind: ItemKind::Use, name: None })
-            }
+            "import_declaration" => Some(SymbolInfo {
+                kind: ItemKind::Use,
+                name: None,
+            }),
             "package_clause" => {
                 let mut cursor = node.walk();
-                let name = node.named_children(&mut cursor)
+                let name = node
+                    .named_children(&mut cursor)
                     .find(|c| c.kind() == "package_identifier")
                     .map(|n| source[n.byte_range()].to_string());
-                Some(SymbolInfo { kind: ItemKind::Mod, name })
+                Some(SymbolInfo {
+                    kind: ItemKind::Mod,
+                    name,
+                })
             }
             _ => None,
         }
@@ -104,41 +124,44 @@ impl LanguageHandler for GoHandler {
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
                 if child.kind() == "type_spec"
-                    && let Some(type_node) = child.child_by_field_name("type") {
-                        match type_node.kind() {
-                            "struct_type" => {
-                                if let Some(field_list) = type_node.child_by_field_name("fields") {
-                                    let mut fc = field_list.walk();
-                                    for field in field_list.named_children(&mut fc) {
-                                        if field.kind() == "field_declaration" {
-                                            let name = field.child_by_field_name("name")
-                                                .map(|n| source[n.byte_range()].to_string());
-                                            result.push(ChildSymbol {
-                                                node: field,
-                                                kind: ItemKind::Const,
-                                                name,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            "interface_type" => {
-                                let mut ic = type_node.walk();
-                                for child_node in type_node.named_children(&mut ic) {
-                                    if child_node.kind() == "method_elem" {
-                                        // method_elem contains the method signature
-                                        let name = child_node.child_by_field_name("name")
+                    && let Some(type_node) = child.child_by_field_name("type")
+                {
+                    match type_node.kind() {
+                        "struct_type" => {
+                            if let Some(field_list) = type_node.child_by_field_name("fields") {
+                                let mut fc = field_list.walk();
+                                for field in field_list.named_children(&mut fc) {
+                                    if field.kind() == "field_declaration" {
+                                        let name = field
+                                            .child_by_field_name("name")
                                             .map(|n| source[n.byte_range()].to_string());
                                         result.push(ChildSymbol {
-                                            node: child_node,
-                                            kind: ItemKind::Method,
+                                            node: field,
+                                            kind: ItemKind::Const,
                                             name,
                                         });
                                     }
                                 }
                             }
-                            _ => {}
                         }
+                        "interface_type" => {
+                            let mut ic = type_node.walk();
+                            for child_node in type_node.named_children(&mut ic) {
+                                if child_node.kind() == "method_elem" {
+                                    // method_elem contains the method signature
+                                    let name = child_node
+                                        .child_by_field_name("name")
+                                        .map(|n| source[n.byte_range()].to_string());
+                                    result.push(ChildSymbol {
+                                        node: child_node,
+                                        kind: ItemKind::Method,
+                                        name,
+                                    });
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
                 }
             }
         }
@@ -151,12 +174,14 @@ impl LanguageHandler for GoHandler {
                 ("var_spec", ItemKind::Static)
             };
             let mut cursor = node.walk();
-            let specs: Vec<_> = node.named_children(&mut cursor)
+            let specs: Vec<_> = node
+                .named_children(&mut cursor)
                 .filter(|c| c.kind() == spec_kind)
                 .collect();
             if specs.len() > 1 {
                 for spec in specs {
-                    let name = spec.child_by_field_name("name")
+                    let name = spec
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                     result.push(ChildSymbol {
                         node: spec,
@@ -204,7 +229,11 @@ impl LanguageHandler for GoHandler {
                 }
                 sig
             }
-            _ => source[node.byte_range()].lines().next().unwrap_or("").to_string(),
+            _ => source[node.byte_range()]
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string(),
         }
     }
 
@@ -225,7 +254,12 @@ impl LanguageHandler for GoHandler {
     }
 
     fn identifier_node_kinds(&self) -> &[&str] {
-        &["identifier", "field_identifier", "type_identifier", "package_identifier"]
+        &[
+            "identifier",
+            "field_identifier",
+            "type_identifier",
+            "package_identifier",
+        ]
     }
 
     fn parse_imports(
@@ -245,25 +279,37 @@ impl LanguageHandler for GoHandler {
 
     fn is_test_item(&self, node: Node, source: &str) -> bool {
         if node.kind() == "function_declaration"
-            && let Some(name_node) = node.child_by_field_name("name") {
-                let name = &source[name_node.byte_range()];
-                return name.starts_with("Test") || name.starts_with("Benchmark") || name.starts_with("Example");
+            && let Some(name_node) = node.child_by_field_name("name")
+        {
+            let name = &source[name_node.byte_range()];
+            return name.starts_with("Test")
+                || name.starts_with("Benchmark")
+                || name.starts_with("Example");
         }
         false
+    }
+
+    /// Go doc comments use plain `//` (not `///`). All `//` comments immediately
+    /// preceding a declaration are its doc comment per godoc convention.
+    fn get_doc_comment(&self, source: &str, node: Node) -> Option<String> {
+        let comments = super::collect_prev_comment_siblings(source, node);
+        if comments.is_empty() {
+            None
+        } else {
+            Some(comments.join("\n"))
+        }
     }
 }
 
 /// In Go, exported names start with an uppercase letter.
 fn go_visibility_from_node(node: Node, source: &str) -> Visibility {
     let name_str = match node.kind() {
-        "function_declaration" => {
-            node.child_by_field_name("name")
-                .map(|n| &source[n.byte_range()])
-        }
-        "method_declaration" => {
-            node.child_by_field_name("name")
-                .map(|n| &source[n.byte_range()])
-        }
+        "function_declaration" => node
+            .child_by_field_name("name")
+            .map(|n| &source[n.byte_range()]),
+        "method_declaration" => node
+            .child_by_field_name("name")
+            .map(|n| &source[n.byte_range()]),
         "type_declaration" => {
             let mut cursor = node.walk();
             node.named_children(&mut cursor)
@@ -271,12 +317,8 @@ fn go_visibility_from_node(node: Node, source: &str) -> Visibility {
                 .and_then(|ts| ts.child_by_field_name("name"))
                 .map(|n| &source[n.byte_range()])
         }
-        "const_declaration" => {
-            extract_first_spec_name_str(node, source, "const_spec")
-        }
-        "var_declaration" => {
-            extract_first_spec_name_str(node, source, "var_spec")
-        }
+        "const_declaration" => extract_first_spec_name_str(node, source, "const_spec"),
+        "var_declaration" => extract_first_spec_name_str(node, source, "var_spec"),
         "package_clause" => return Visibility::Public,
         "import_declaration" => return Visibility::Private,
         _ => None,
@@ -297,7 +339,11 @@ fn extract_first_spec_name(node: Node, source: &str, spec_kind: &str) -> Option<
         .map(|n| source[n.byte_range()].to_string())
 }
 
-fn extract_first_spec_name_str<'a>(node: Node<'a>, source: &'a str, spec_kind: &str) -> Option<&'a str> {
+fn extract_first_spec_name_str<'a>(
+    node: Node<'a>,
+    source: &'a str,
+    spec_kind: &str,
+) -> Option<&'a str> {
     let mut cursor = node.walk();
     node.named_children(&mut cursor)
         .find(|c| c.kind() == spec_kind)
@@ -305,11 +351,7 @@ fn extract_first_spec_name_str<'a>(node: Node<'a>, source: &'a str, spec_kind: &
         .map(|n| &source[n.byte_range()])
 }
 
-fn parse_go_imports(
-    root: &Node,
-    source: &str,
-    file_path: &Path,
-) -> Vec<crate::xrefs::ImportEdge> {
+fn parse_go_imports(root: &Node, source: &str, file_path: &Path) -> Vec<crate::xrefs::ImportEdge> {
     let mut edges = Vec::new();
     let mut cursor = root.walk();
     for child in root.named_children(&mut cursor) {
@@ -333,15 +375,16 @@ fn parse_go_imports(
                         let mut lc = import_child.walk();
                         for spec in import_child.named_children(&mut lc) {
                             if spec.kind() == "import_spec"
-                                && let Some(path_node) = spec.child_by_field_name("path") {
-                                    let raw = &source[path_node.byte_range()];
-                                    let import_path = raw.trim_matches('"');
-                                    edges.push(crate::xrefs::ImportEdge {
-                                        importing_file: file_path.to_path_buf(),
-                                        symbols: vec![],
-                                        source: import_path.to_string(),
-                                        resolved_path: None,
-                                    });
+                                && let Some(path_node) = spec.child_by_field_name("path")
+                            {
+                                let raw = &source[path_node.byte_range()];
+                                let import_path = raw.trim_matches('"');
+                                edges.push(crate::xrefs::ImportEdge {
+                                    importing_file: file_path.to_path_buf(),
+                                    symbols: vec![],
+                                    source: import_path.to_string(),
+                                    resolved_path: None,
+                                });
                             }
                         }
                     }

--- a/src/handler/java.rs
+++ b/src/handler/java.rs
@@ -79,8 +79,9 @@ fn field_name(node: Node, source: &str) -> Option<String> {
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         if child.kind() == "variable_declarator"
-            && let Some(name_node) = child.child_by_field_name("name") {
-                return Some(source[name_node.byte_range()].to_string());
+            && let Some(name_node) = child.child_by_field_name("name")
+        {
+            return Some(source[name_node.byte_range()].to_string());
         }
     }
     None
@@ -221,8 +222,9 @@ impl LanguageHandler for JavaHandler {
 
         // Return type (for methods)
         if node.kind() == "method_declaration"
-            && let Some(ret) = node.child_by_field_name("type") {
-                parts.push(source[ret.byte_range()].to_string());
+            && let Some(ret) = node.child_by_field_name("type")
+        {
+            parts.push(source[ret.byte_range()].to_string());
         }
 
         // Name

--- a/src/handler/javascript.rs
+++ b/src/handler/javascript.rs
@@ -180,7 +180,11 @@ impl LanguageHandler for JavaScriptHandler {
     }
 
     fn identifier_node_kinds(&self) -> &[&str] {
-        &["identifier", "property_identifier", "shorthand_property_identifier_pattern"]
+        &[
+            "identifier",
+            "property_identifier",
+            "shorthand_property_identifier_pattern",
+        ]
     }
 
     fn parse_imports(
@@ -202,6 +206,37 @@ impl LanguageHandler for JavaScriptHandler {
 
     fn is_test_item(&self, _node: Node, _source: &str) -> bool {
         false
+    }
+
+    /// JavaScript/JSDoc: accept `/**` blocks, handle export_statement wrapping.
+    fn get_doc_comment(&self, source: &str, node: Node) -> Option<String> {
+        let check_node = if node
+            .parent()
+            .is_some_and(|p| p.kind() == "export_statement")
+        {
+            node.parent().unwrap()
+        } else {
+            node
+        };
+        let effective = super::skip_past_attributes(check_node);
+        let comments = super::collect_prev_comment_siblings(source, effective);
+        if comments.is_empty() {
+            return None;
+        }
+        let doc: Vec<&String> = comments
+            .iter()
+            .filter(|c| c.trim().starts_with("/**"))
+            .collect();
+        if doc.is_empty() {
+            None
+        } else {
+            Some(
+                doc.iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        }
     }
 }
 

--- a/src/handler/kotlin.rs
+++ b/src/handler/kotlin.rs
@@ -25,19 +25,18 @@ const SYMBOL_QUERY: &str = r#"
 /// Find the first child of a given kind.
 fn first_child_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
     let mut cursor = node.walk();
-    node.named_children(&mut cursor).find(|&child| child.kind() == kind)
+    node.named_children(&mut cursor)
+        .find(|&child| child.kind() == kind)
 }
 
 /// Extract the name from a node that uses `type_identifier` for its name (classes, objects).
 fn type_name(node: Node, source: &str) -> Option<String> {
-    first_child_of_kind(node, "type_identifier")
-        .map(|n| source[n.byte_range()].to_string())
+    first_child_of_kind(node, "type_identifier").map(|n| source[n.byte_range()].to_string())
 }
 
 /// Extract the name from a node that uses `simple_identifier` (functions, properties).
 fn simple_name(node: Node, source: &str) -> Option<String> {
-    first_child_of_kind(node, "simple_identifier")
-        .map(|n| source[n.byte_range()].to_string())
+    first_child_of_kind(node, "simple_identifier").map(|n| source[n.byte_range()].to_string())
 }
 
 /// Extract property name from a property_declaration.
@@ -167,13 +166,9 @@ impl LanguageHandler for KotlinHandler {
 
     fn child_symbols<'a>(&self, node: Node<'a>, source: &str) -> Vec<ChildSymbol<'a>> {
         let body = match node.kind() {
-            "class_declaration" => {
-                first_child_of_kind(node, "class_body")
-                    .or_else(|| first_child_of_kind(node, "enum_class_body"))
-            }
-            "object_declaration" | "companion_object" => {
-                first_child_of_kind(node, "class_body")
-            }
+            "class_declaration" => first_child_of_kind(node, "class_body")
+                .or_else(|| first_child_of_kind(node, "enum_class_body")),
+            "object_declaration" | "companion_object" => first_child_of_kind(node, "class_body"),
             _ => return vec![],
         };
 
@@ -210,8 +205,7 @@ impl LanguageHandler for KotlinHandler {
                     });
                 }
                 "companion_object" => {
-                    let name = type_name(child, source)
-                        .unwrap_or_else(|| "Companion".to_string());
+                    let name = type_name(child, source).unwrap_or_else(|| "Companion".to_string());
                     result.push(ChildSymbol {
                         node: child,
                         kind: ItemKind::Class,

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -11,8 +11,8 @@ pub mod typescript;
 // Re-export types used in the handler API so consumers don't need to reach into extractor
 pub use crate::extractor::{ItemKind, Visibility};
 pub use crate::languages::{Language, ts_language};
-use tree_sitter::Node;
 use std::path::Path;
+use tree_sitter::Node;
 
 /// Information about a classified symbol node.
 #[derive(Debug, Clone)]
@@ -28,6 +28,79 @@ pub struct ChildSymbol<'a> {
     pub node: Node<'a>,
     pub kind: ItemKind,
     pub name: Option<String>,
+}
+
+/// Collect preceding comment sibling nodes in source order.
+/// Shared helper for doc comment extraction across languages.
+pub fn collect_prev_comment_siblings(source: &str, node: Node) -> Vec<String> {
+    let comment_kinds = [
+        "comment",
+        "line_comment",
+        "block_comment",
+        "multiline_comment",
+    ];
+    let mut comments = Vec::new();
+    let mut current = node;
+    while let Some(prev) = current.prev_sibling() {
+        if comment_kinds.contains(&prev.kind()) {
+            comments.push(source[prev.start_byte()..prev.end_byte()].to_string());
+            current = prev;
+        } else {
+            break;
+        }
+    }
+    comments.reverse();
+    comments
+}
+
+/// Skip backwards past attribute_item / decorator siblings to find the effective node.
+pub fn skip_past_attributes(node: Node) -> Node {
+    let mut current = node;
+    loop {
+        match current.prev_sibling() {
+            Some(prev) if prev.kind() == "attribute_item" || prev.kind() == "decorator" => {
+                current = prev;
+            }
+            _ => break,
+        }
+    }
+    current
+}
+
+/// Default doc comment extraction: walk back past attrs, collect preceding comments,
+/// filter for `///` or `/**` style (works for Rust, C#, Kotlin, Java).
+pub fn default_get_doc_comment(source: &str, node: Node) -> Option<String> {
+    let effective = skip_past_attributes(node);
+    let comments = collect_prev_comment_siblings(source, effective);
+
+    if comments.is_empty() {
+        return None;
+    }
+
+    // Filter for doc comments (/// or /**)
+    let doc_comments: Vec<&String> = comments
+        .iter()
+        .filter(|c| {
+            let trimmed = c.trim();
+            trimmed.starts_with("///") || trimmed.starts_with("/**") || trimmed.starts_with("* ")
+        })
+        .collect();
+
+    if doc_comments.is_empty() {
+        // Check for standalone /** block
+        if comments.iter().any(|c| c.trim().starts_with("/**")) {
+            return Some(comments.join("\n"));
+        }
+        return None;
+    }
+
+    Some(
+        doc_comments
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }
 
 /// A language-specific handler for codehud operations using tree-sitter's native Node API.
@@ -87,37 +160,26 @@ pub trait LanguageHandler: Send + Sync {
     fn max_query_depth(&self) -> u32 {
         2
     }
+
+    /// Extract the doc comment attached to the given item node, if any.
+    /// Default implementation handles `///` and `/**` style comments (Rust, C#, Kotlin, Java).
+    /// Languages with different conventions should override this.
+    fn get_doc_comment(&self, source: &str, node: Node) -> Option<String> {
+        default_get_doc_comment(source, node)
+    }
 }
 
 /// Get a `LanguageHandler` implementation for the given language, if available.
 pub fn handler_for(language: Language) -> Option<Box<dyn LanguageHandler>> {
     match language {
-        Language::TypeScript | Language::Tsx => {
-            Some(Box::new(typescript::TypeScriptHandler))
-        }
-        Language::JavaScript | Language::Jsx => {
-            Some(Box::new(javascript::JavaScriptHandler))
-        }
-        Language::Python => {
-            Some(Box::new(python::PythonHandler))
-        }
-        Language::Rust => {
-            Some(Box::new(rust::RustHandler))
-        }
-        Language::Java => {
-            Some(Box::new(java::JavaHandler))
-        }
-        Language::Go => {
-            Some(Box::new(go::GoHandler))
-        }
-        Language::Cpp => {
-            Some(Box::new(cpp::CppHandler))
-        }
-        Language::CSharp => {
-            Some(Box::new(csharp::CSharpHandler))
-        }
-        Language::Kotlin => {
-            Some(Box::new(kotlin::KotlinHandler))
-        }
+        Language::TypeScript | Language::Tsx => Some(Box::new(typescript::TypeScriptHandler)),
+        Language::JavaScript | Language::Jsx => Some(Box::new(javascript::JavaScriptHandler)),
+        Language::Python => Some(Box::new(python::PythonHandler)),
+        Language::Rust => Some(Box::new(rust::RustHandler)),
+        Language::Java => Some(Box::new(java::JavaHandler)),
+        Language::Go => Some(Box::new(go::GoHandler)),
+        Language::Cpp => Some(Box::new(cpp::CppHandler)),
+        Language::CSharp => Some(Box::new(csharp::CSharpHandler)),
+        Language::Kotlin => Some(Box::new(kotlin::KotlinHandler)),
     }
 }

--- a/src/handler/python.rs
+++ b/src/handler/python.rs
@@ -109,10 +109,11 @@ impl LanguageHandler for PythonHandler {
             let mut cursor = inner.walk();
             for child in inner.named_children(&mut cursor) {
                 if child.kind() == "assignment"
-                    && let Some(left) = child.child_by_field_name("left") {
-                        let name = &source[left.byte_range()];
-                        return python_visibility(name);
-                    }
+                    && let Some(left) = child.child_by_field_name("left")
+                {
+                    let name = &source[left.byte_range()];
+                    return python_visibility(name);
+                }
             }
         }
 
@@ -207,14 +208,15 @@ impl LanguageHandler for PythonHandler {
                     for inner in child.named_children(&mut inner_cursor) {
                         if inner.kind() == "assignment"
                             && let Some(left) = inner.child_by_field_name("left")
-                                && left.kind() == "identifier" {
-                                    let name = Some(source[left.byte_range()].to_string());
-                                    result.push(ChildSymbol {
-                                        node: child,
-                                        kind: ItemKind::Const,
-                                        name,
-                                    });
-                                }
+                            && left.kind() == "identifier"
+                        {
+                            let name = Some(source[left.byte_range()].to_string());
+                            result.push(ChildSymbol {
+                                node: child,
+                                kind: ItemKind::Const,
+                                name,
+                            });
+                        }
                     }
                 }
                 _ => {}
@@ -314,6 +316,33 @@ impl LanguageHandler for PythonHandler {
             }
         }
         false
+    }
+
+    /// Python docstrings are the first `expression_statement > string` inside the body block,
+    /// not preceding comment siblings.
+    fn get_doc_comment(&self, source: &str, node: Node) -> Option<String> {
+        // Unwrap decorated_definition to get to the actual function/class
+        let inner = if node.kind() == "decorated_definition" {
+            unwrap_decorated(node).unwrap_or(node)
+        } else {
+            node
+        };
+
+        let body = inner.child_by_field_name("body")?;
+        if body.kind() != "block" {
+            return None;
+        }
+        let mut cursor = body.walk();
+        let first = body.named_children(&mut cursor).next()?;
+        if first.kind() != "expression_statement" {
+            return None;
+        }
+        let mut ec = first.walk();
+        let string_node = first.named_children(&mut ec).next()?;
+        if string_node.kind() != "string" && string_node.kind() != "concatenated_string" {
+            return None;
+        }
+        Some(source[string_node.byte_range()].to_string())
     }
 }
 

--- a/src/handler/rust.rs
+++ b/src/handler/rust.rs
@@ -1,7 +1,7 @@
 use super::{ChildSymbol, LanguageHandler, SymbolInfo};
 use crate::extractor::{ItemKind, Visibility};
-use tree_sitter::Node;
 use std::path::Path;
+use tree_sitter::Node;
 
 pub struct RustHandler;
 
@@ -70,10 +70,9 @@ impl LanguageHandler for RustHandler {
                     .map(|n| source[n.byte_range()].to_string())
             }
             "use_declaration" => None,
-            _ => {
-                node.child_by_field_name("name")
-                    .map(|n| source[n.byte_range()].to_string())
-            }
+            _ => node
+                .child_by_field_name("name")
+                .map(|n| source[n.byte_range()].to_string()),
         };
 
         Some(SymbolInfo { kind, name })
@@ -98,7 +97,8 @@ impl LanguageHandler for RustHandler {
                     for child in body.named_children(&mut cursor) {
                         match child.kind() {
                             "function_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -107,7 +107,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "const_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -116,7 +117,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "type_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -135,7 +137,8 @@ impl LanguageHandler for RustHandler {
                     for child in body.named_children(&mut cursor) {
                         match child.kind() {
                             "function_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -144,7 +147,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "function_signature_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -153,7 +157,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "const_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -162,7 +167,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "type_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -180,7 +186,8 @@ impl LanguageHandler for RustHandler {
                     let mut cursor = body.walk();
                     for child in body.named_children(&mut cursor) {
                         if child.kind() == "enum_variant" {
-                            let name = child.child_by_field_name("name")
+                            let name = child
+                                .child_by_field_name("name")
                                 .map(|n| source[n.byte_range()].to_string());
                             result.push(ChildSymbol {
                                 node: child,
@@ -198,7 +205,8 @@ impl LanguageHandler for RustHandler {
                     for child in body.named_children(&mut cursor) {
                         match child.kind() {
                             "function_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -207,7 +215,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "struct_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -216,7 +225,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "enum_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -225,7 +235,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "const_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -234,7 +245,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "type_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -243,7 +255,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "trait_item" => {
-                                let name = child.child_by_field_name("name")
+                                let name = child
+                                    .child_by_field_name("name")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -252,7 +265,8 @@ impl LanguageHandler for RustHandler {
                                 });
                             }
                             "impl_item" => {
-                                let name = child.child_by_field_name("type")
+                                let name = child
+                                    .child_by_field_name("type")
                                     .map(|n| source[n.byte_range()].to_string());
                                 result.push(ChildSymbol {
                                     node: child,
@@ -271,7 +285,8 @@ impl LanguageHandler for RustHandler {
                     let mut cursor = body.walk();
                     for child in body.named_children(&mut cursor) {
                         if child.kind() == "field_declaration" {
-                            let name = child.child_by_field_name("name")
+                            let name = child
+                                .child_by_field_name("name")
                                 .map(|n| source[n.byte_range()].to_string());
                             result.push(ChildSymbol {
                                 node: child,
@@ -348,10 +363,19 @@ impl LanguageHandler for RustHandler {
 
     fn definition_parent_kinds(&self) -> &[&str] {
         &[
-            "function_item", "struct_item", "enum_item", "trait_item",
-            "impl_item", "mod_item", "const_item", "static_item",
-            "type_item", "macro_definition", "let_declaration",
-            "parameter", "closure_expression",
+            "function_item",
+            "struct_item",
+            "enum_item",
+            "trait_item",
+            "impl_item",
+            "mod_item",
+            "const_item",
+            "static_item",
+            "type_item",
+            "macro_definition",
+            "let_declaration",
+            "parameter",
+            "closure_expression",
         ]
     }
 
@@ -377,12 +401,13 @@ impl LanguageHandler for RustHandler {
     fn is_test_item(&self, node: Node, source: &str) -> bool {
         // Check for #[test] or #[cfg(test)] attributes
         if let Some(prev) = node.prev_sibling()
-            && prev.kind() == "attribute_item" {
-                let text = &source[prev.byte_range()];
-                if text.contains("#[test]") || text.contains("#[cfg(test)]") {
-                    return true;
-                }
+            && prev.kind() == "attribute_item"
+        {
+            let text = &source[prev.byte_range()];
+            if text.contains("#[test]") || text.contains("#[cfg(test)]") {
+                return true;
             }
+        }
         // Check for #[test] on the node itself via attribute field
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {

--- a/src/handler/typescript.rs
+++ b/src/handler/typescript.rs
@@ -1,7 +1,7 @@
 use super::{ChildSymbol, LanguageHandler, SymbolInfo};
 use crate::extractor::{ItemKind, Visibility};
-use tree_sitter::Node;
 use std::path::Path;
+use tree_sitter::Node;
 
 pub struct TypeScriptHandler;
 
@@ -88,7 +88,8 @@ impl LanguageHandler for TypeScriptHandler {
         let (kind_node, name_source) = if node.kind() == "export_statement" {
             // Unwrap to inner declaration
             let mut cursor = node.walk();
-            let inner = node.named_children(&mut cursor)
+            let inner = node
+                .named_children(&mut cursor)
                 .find(|c| c.kind() != "decorator")?;
             (inner, source)
         } else {
@@ -174,7 +175,8 @@ impl LanguageHandler for TypeScriptHandler {
         for child in body.named_children(&mut cursor) {
             match child.kind() {
                 "method_definition" => {
-                    let name = child.child_by_field_name("name")
+                    let name = child
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                     result.push(ChildSymbol {
                         node: child,
@@ -183,7 +185,8 @@ impl LanguageHandler for TypeScriptHandler {
                     });
                 }
                 "abstract_method_signature" => {
-                    let name = child.child_by_field_name("name")
+                    let name = child
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                     result.push(ChildSymbol {
                         node: child,
@@ -192,7 +195,8 @@ impl LanguageHandler for TypeScriptHandler {
                     });
                 }
                 "public_field_definition" | "property_definition" => {
-                    let name = child.child_by_field_name("name")
+                    let name = child
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                     result.push(ChildSymbol {
                         node: child,
@@ -201,7 +205,8 @@ impl LanguageHandler for TypeScriptHandler {
                     });
                 }
                 "property_signature" => {
-                    let name = child.child_by_field_name("name")
+                    let name = child
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                     result.push(ChildSymbol {
                         node: child,
@@ -224,7 +229,8 @@ impl LanguageHandler for TypeScriptHandler {
         // Unwrap export_statement to get the actual declaration
         let (prefix, inner) = if node.kind() == "export_statement" {
             let mut cursor = node.walk();
-            let inner = node.named_children(&mut cursor)
+            let inner = node
+                .named_children(&mut cursor)
                 .find(|c| c.kind() != "decorator" && c.kind() != "comment");
             match inner {
                 Some(n) => ("export ", n),
@@ -289,15 +295,27 @@ impl LanguageHandler for TypeScriptHandler {
 
     fn definition_parent_kinds(&self) -> &[&str] {
         &[
-            "function_declaration", "class_declaration", "interface_declaration",
-            "type_alias_declaration", "enum_declaration", "method_definition",
-            "variable_declarator", "property_signature", "public_field_definition",
-            "required_parameter", "optional_parameter",
+            "function_declaration",
+            "class_declaration",
+            "interface_declaration",
+            "type_alias_declaration",
+            "enum_declaration",
+            "method_definition",
+            "variable_declarator",
+            "property_signature",
+            "public_field_definition",
+            "required_parameter",
+            "optional_parameter",
         ]
     }
 
     fn identifier_node_kinds(&self) -> &[&str] {
-        &["identifier", "type_identifier", "property_identifier", "shorthand_property_identifier_pattern"]
+        &[
+            "identifier",
+            "type_identifier",
+            "property_identifier",
+            "shorthand_property_identifier_pattern",
+        ]
     }
 
     fn parse_imports(
@@ -320,6 +338,39 @@ impl LanguageHandler for TypeScriptHandler {
     fn is_test_item(&self, _node: Node, _source: &str) -> bool {
         false
     }
+
+    /// TypeScript/JSDoc: accept `/**` blocks, handle export_statement wrapping.
+    fn get_doc_comment(&self, source: &str, node: Node) -> Option<String> {
+        // For export_statement, check the outer node's prev siblings
+        let check_node = if node
+            .parent()
+            .is_some_and(|p| p.kind() == "export_statement")
+        {
+            node.parent().unwrap()
+        } else {
+            node
+        };
+        let effective = super::skip_past_attributes(check_node);
+        let comments = super::collect_prev_comment_siblings(source, effective);
+        if comments.is_empty() {
+            return None;
+        }
+        // Keep only JSDoc blocks (/** ... */)
+        let doc: Vec<&String> = comments
+            .iter()
+            .filter(|c| c.trim().starts_with("/**"))
+            .collect();
+        if doc.is_empty() {
+            None
+        } else {
+            Some(
+                doc.iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            )
+        }
+    }
 }
 
 /// Check if a lexical_declaration is an arrow function (const foo = (...) => ...)
@@ -329,10 +380,10 @@ fn is_arrow_function_declaration(node: Node, _source: &str) -> bool {
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if child.kind() == "variable_declarator" {
-            if let Some(value) = child.child_by_field_name("value") {
-                return value.kind() == "arrow_function";
-            }
+        if child.kind() == "variable_declarator"
+            && let Some(value) = child.child_by_field_name("value")
+        {
+            return value.kind() == "arrow_function";
         }
     }
     false
@@ -353,7 +404,8 @@ fn try_arrow_function_signature(node: Node, source: &str) -> Option<String> {
     };
 
     let mut cursor = lex_node.walk();
-    let declarator = lex_node.children(&mut cursor)
+    let declarator = lex_node
+        .children(&mut cursor)
         .find(|c| c.kind() == "variable_declarator")?;
 
     let value = declarator.child_by_field_name("value")?;
@@ -367,18 +419,24 @@ fn try_arrow_function_signature(node: Node, source: &str) -> Option<String> {
     // Get the declaration keyword (const/let)
     let keyword = {
         let mut c2 = lex_node.walk();
-        lex_node.children(&mut c2)
+        lex_node
+            .children(&mut c2)
             .find(|c| c.kind() == "const" || c.kind() == "let" || c.kind() == "var")
             .map(|c| &source[c.byte_range()])
             .unwrap_or("const")
     };
 
-    let export_prefix = if node.kind() == "export_statement" { "export " } else { "" };
+    let export_prefix = if node.kind() == "export_statement" {
+        "export "
+    } else {
+        ""
+    };
 
     // Type annotation on the declarator name
     let type_ann = {
         let mut c3 = declarator.walk();
-        declarator.children(&mut c3)
+        declarator
+            .children(&mut c3)
             .find(|c| c.kind() == "type_annotation")
             .map(|c| source[c.byte_range()].to_string())
     };
@@ -394,7 +452,8 @@ fn try_arrow_function_signature(node: Node, source: &str) -> Option<String> {
         }
     }
 
-    let params = value.child_by_field_name("parameters")
+    let params = value
+        .child_by_field_name("parameters")
         .map(|p| source[p.byte_range()].to_string());
 
     // Return type from arrow function
@@ -414,7 +473,10 @@ fn try_arrow_function_signature(node: Node, source: &str) -> Option<String> {
         let type_params = parts.join("");
         let params_str = params.unwrap_or_else(|| "()".to_string());
         let ret = ret_type.map(|r| format!(" {}", r)).unwrap_or_default();
-        Some(format!("{}{} {} = {}{}{} => ...", export_prefix, keyword, name_text, type_params, params_str, ret))
+        Some(format!(
+            "{}{} {} = {}{}{} => ...",
+            export_prefix, keyword, name_text, type_params, params_str, ret
+        ))
     }
 }
 
@@ -425,16 +487,16 @@ fn extract_name(node: Node, source: &str) -> Option<String> {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 if child.kind() == "variable_declarator" {
-                    return child.child_by_field_name("name")
+                    return child
+                        .child_by_field_name("name")
                         .map(|n| source[n.byte_range()].to_string());
                 }
             }
             None
         }
         "import_statement" => None,
-        _ => {
-            node.child_by_field_name("name")
-                .map(|n| source[n.byte_range()].to_string())
-        }
+        _ => node
+            .child_by_field_name("name")
+            .map(|n| source[n.byte_range()].to_string()),
     }
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -2,11 +2,11 @@ pub mod cpp;
 pub mod csharp;
 pub mod go;
 pub mod java;
+pub mod javascript;
 pub mod kotlin;
+pub mod python;
 pub mod rust;
 pub mod typescript;
-pub mod python;
-pub mod javascript;
 
 use crate::error::CodehudError;
 use std::path::Path;
@@ -106,7 +106,10 @@ static LANG_TABLE: &[LangEntry] = &[
 ];
 
 fn find_entry(lang: Language) -> &'static LangEntry {
-    LANG_TABLE.iter().find(|e| e.lang == lang).expect("Language not registered")
+    LANG_TABLE
+        .iter()
+        .find(|e| e.lang == lang)
+        .expect("Language not registered")
 }
 
 impl Language {
@@ -148,20 +151,87 @@ pub fn is_text_file(path: &Path) -> bool {
     }
     // Common text file extensions for passthrough
     const TEXT_EXTENSIONS: &[&str] = &[
-        "toml", "yaml", "yml", "json", "md", "txt", "csv", "xml", "html", "css",
-        "scss", "less", "sql", "sh", "bash", "zsh", "fish", "bat", "ps1",
-        "env", "ini", "cfg", "conf", "config", "properties",
-        "dockerfile", "dockerignore", "gitignore", "gitattributes",
-        "editorconfig", "prettierrc", "eslintrc",
-        "lock", "log", "diff", "patch",
-        "c", "h", "cpp", "hpp", "cc", "java", "go", "rb", "php", "swift",
-        "kt", "kts", "scala", "r", "lua", "pl", "pm", "ex", "exs",
-        "hs", "ml", "mli", "clj", "cljs", "edn", "elm", "erl", "hrl",
-        "vim", "makefile", "cmake", "gradle", "sbt",
-        "tf", "tfvars", "hcl", "nix",
-        "graphql", "gql", "proto", "thrift", "avsc",
+        "toml",
+        "yaml",
+        "yml",
+        "json",
+        "md",
+        "txt",
+        "csv",
+        "xml",
+        "html",
+        "css",
+        "scss",
+        "less",
+        "sql",
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+        "bat",
+        "ps1",
+        "env",
+        "ini",
+        "cfg",
+        "conf",
+        "config",
+        "properties",
+        "dockerfile",
+        "dockerignore",
+        "gitignore",
+        "gitattributes",
+        "editorconfig",
+        "prettierrc",
+        "eslintrc",
+        "lock",
+        "log",
+        "diff",
+        "patch",
+        "c",
+        "h",
+        "cpp",
+        "hpp",
+        "cc",
+        "java",
+        "go",
+        "rb",
+        "php",
+        "swift",
+        "kt",
+        "kts",
+        "scala",
+        "r",
+        "lua",
+        "pl",
+        "pm",
+        "ex",
+        "exs",
+        "hs",
+        "ml",
+        "mli",
+        "clj",
+        "cljs",
+        "edn",
+        "elm",
+        "erl",
+        "hrl",
+        "vim",
+        "makefile",
+        "cmake",
+        "gradle",
+        "sbt",
+        "tf",
+        "tfvars",
+        "hcl",
+        "nix",
+        "graphql",
+        "gql",
+        "proto",
+        "thrift",
+        "avsc",
     ];
-    let ext = path.extension()
+    let ext = path
+        .extension()
         .and_then(|e| e.to_str())
         .map(|e| e.to_lowercase());
     match ext {
@@ -170,12 +240,28 @@ pub fn is_text_file(path: &Path) -> bool {
             // Files without extension: check known filenames
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             let lower = name.to_lowercase();
-            matches!(lower.as_str(),
-                "makefile" | "dockerfile" | "vagrantfile" | "gemfile" |
-                "rakefile" | "procfile" | "brewfile" | "justfile" |
-                ".env" | ".gitignore" | ".gitattributes" | ".editorconfig" |
-                ".dockerignore" | ".prettierrc" | ".eslintrc" |
-                "license" | "readme" | "changelog" | "authors" | "contributors"
+            matches!(
+                lower.as_str(),
+                "makefile"
+                    | "dockerfile"
+                    | "vagrantfile"
+                    | "gemfile"
+                    | "rakefile"
+                    | "procfile"
+                    | "brewfile"
+                    | "justfile"
+                    | ".env"
+                    | ".gitignore"
+                    | ".gitattributes"
+                    | ".editorconfig"
+                    | ".dockerignore"
+                    | ".prettierrc"
+                    | ".eslintrc"
+                    | "license"
+                    | "readme"
+                    | "changelog"
+                    | "authors"
+                    | "contributors"
             )
         }
     }
@@ -185,7 +271,6 @@ pub fn is_text_file(path: &Path) -> bool {
 pub fn ts_language(lang: Language) -> tree_sitter::Language {
     (find_entry(lang).ts_language_fn)()
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,33 @@
-mod error;
 pub mod agent;
-pub mod skill;
-pub(crate) mod parser;
-pub(crate) mod extractor;
-pub(crate) mod languages;
-mod output;
-pub mod test_detect;
-pub mod walk;
-pub mod editor;
-pub mod search;
-pub mod tree;
-pub mod references;
-pub mod xrefs;
-pub(crate) mod sfc;
-pub(crate) mod pipeline;
-pub mod handler;
-pub mod dispatch;
-pub mod git;
 pub mod diff;
 pub mod diff_cli;
+pub mod dispatch;
+pub mod editor;
+mod error;
+pub(crate) mod extractor;
+pub mod git;
+pub mod handler;
+pub(crate) mod languages;
+mod output;
+pub(crate) mod parser;
+pub(crate) mod pipeline;
+pub mod references;
+pub mod search;
+pub(crate) mod sfc;
+pub mod skill;
+pub mod test_detect;
 pub mod tokens;
+pub mod tree;
+pub mod walk;
+pub mod xrefs;
 
 use std::fs;
 use std::path::Path;
 
 pub use error::CodehudError;
-pub use output::OutputFormat;
-pub use languages::{Language, detect_language};
 use extractor::{Item, ItemKind};
+pub use languages::{Language, detect_language};
+pub use output::OutputFormat;
 
 /// Options for processing paths
 #[derive(Default)]
@@ -56,15 +56,13 @@ pub struct ProcessOptions {
     pub yes: bool,
     pub warn_threshold: usize,
     pub token_budget: Option<usize>,
+    pub with_comments: bool,
 }
 
 /// Process a file or directory and return formatted output
-pub fn process_path(
-    path: &str,
-    options: ProcessOptions,
-) -> Result<String, CodehudError> {
+pub fn process_path(path: &str, options: ProcessOptions) -> Result<String, CodehudError> {
     let path = Path::new(path);
-    
+
     if !path.exists() {
         return Err(CodehudError::PathNotFound(path.display().to_string()));
     }
@@ -91,7 +89,8 @@ pub fn process_path(
     }
 
     // Collect source sizes for stats before filtering consumes the items
-    let source_sizes: Vec<(usize, usize)> = file_items.iter().map(|fi| (fi.lines, fi.bytes)).collect();
+    let source_sizes: Vec<(usize, usize)> =
+        file_items.iter().map(|fi| (fi.lines, fi.bytes)).collect();
 
     // Stage 3: Apply filters
     let filtered = pipeline::apply_filters(file_items, &options);
@@ -160,9 +159,15 @@ pub fn extract_lines(path_str: &str, lines_arg: &str, json: bool) -> Result<Stri
             content: String,
         }
         let lines_vec: Vec<&str> = source.lines().collect();
-        let entries: Vec<LineEntry> = lines_vec.iter().enumerate()
-            .take(end).skip(start - 1)
-            .map(|(i, line)| LineEntry { line: i + 1, content: line.to_string() })
+        let entries: Vec<LineEntry> = lines_vec
+            .iter()
+            .enumerate()
+            .take(end)
+            .skip(start - 1)
+            .map(|(i, line)| LineEntry {
+                line: i + 1,
+                content: line.to_string(),
+            })
             .collect();
         let output = LinesOutput {
             file: path_str.to_string(),
@@ -188,7 +193,6 @@ pub fn extract_lines(path_str: &str, lines_arg: &str, json: bool) -> Result<Stri
 
     Ok(output)
 }
-
 
 fn parse_line_range(arg: &str) -> Result<(usize, usize), CodehudError> {
     let parts: Vec<&str> = arg.split('-').collect();
@@ -235,7 +239,9 @@ fn inline_expand_symbols(
     for item in items.iter_mut() {
         // Check if this top-level item matches an expand symbol
         if let Some(ref name) = item.name
-            && let Some(exp) = expanded.iter().find(|e| e.name.as_deref() == Some(name.as_str()))
+            && let Some(exp) = expanded
+                .iter()
+                .find(|e| e.name.as_deref() == Some(name.as_str()))
         {
             item.content = exp.content.clone();
             item.body = exp.body.clone();
@@ -244,7 +250,10 @@ fn inline_expand_symbols(
         }
 
         // For containers (impl/class/trait), check if any expanded symbol is a member
-        if matches!(item.kind, ItemKind::Class | ItemKind::Impl | ItemKind::Trait) {
+        if matches!(
+            item.kind,
+            ItemKind::Class | ItemKind::Impl | ItemKind::Trait
+        ) {
             for exp in &expanded {
                 if let Some(ref exp_name) = exp.name {
                     // Check if this expanded item's line range falls within the container
@@ -252,7 +261,8 @@ fn inline_expand_symbols(
                         // Get the full source of the expanded method
                         let full_source = &exp.content;
                         // Find the signature line in the container outline and replace it
-                        item.content = replace_member_in_outline(&item.content, exp_name, full_source);
+                        item.content =
+                            replace_member_in_outline(&item.content, exp_name, full_source);
                     }
                 }
             }
@@ -268,8 +278,10 @@ fn replace_member_in_outline(outline: &str, member_name: &str, full_source: &str
     while i < lines.len() {
         let trimmed = lines[i].trim();
         // Match signature lines like "    fn greeting (&self) -> String" or "    pub fn new (...) -> Self"
-        if (trimmed.contains(&format!("fn {member_name} ")) || trimmed.contains(&format!("fn {member_name}("))) 
-            && !trimmed.contains('{')  // not already expanded
+        if (trimmed.contains(&format!("fn {member_name} "))
+            || trimmed.contains(&format!("fn {member_name}(")))
+            && !trimmed.contains('{')
+        // not already expanded
         {
             // Replace with indented full source
             for src_line in full_source.lines() {
@@ -287,9 +299,14 @@ fn replace_member_in_outline(outline: &str, member_name: &str, full_source: &str
             // Skip continuation line of a multi-line signature (e.g. closing paren on next line)
             if i + 1 < lines.len() {
                 let next = lines[i + 1].trim();
-                let is_boundary = next.is_empty() || next.starts_with("fn ") || next.starts_with("pub ")
-                    || next == "}" || next.starts_with("///") || next.starts_with("/**")
-                    || next.starts_with("#[") || next.starts_with("@");
+                let is_boundary = next.is_empty()
+                    || next.starts_with("fn ")
+                    || next.starts_with("pub ")
+                    || next == "}"
+                    || next.starts_with("///")
+                    || next.starts_with("/**")
+                    || next.starts_with("#[")
+                    || next.starts_with("@");
                 if !is_boundary && next.contains(')') && !next.contains('{') {
                     i += 1;
                 }
@@ -328,7 +345,9 @@ fn expand_with_dispatch(
     // 1. Qualified names → dispatch first
     if let Some(ref h) = handler {
         for sym in &qualified {
-            if let Some(mut items) = dispatch::expand_symbol(source, tree, h.as_ref(), language, sym) {
+            if let Some(mut items) =
+                dispatch::expand_symbol(source, tree, h.as_ref(), language, sym)
+            {
                 all_items.append(&mut items);
             }
         }
@@ -336,20 +355,31 @@ fn expand_with_dispatch(
 
     // 2. Simple names → handler dispatch first, old path for remainder
     if !simple.is_empty() {
-        let mut found_by_handler: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut found_by_handler: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         if let Some(ref h) = handler {
             for name in &simple {
                 // Try top-level symbol lookup via handler
-                if let Some(node) = dispatch::find_symbol_node_by_query(source, tree, h.as_ref(), language, name)
-                    && let Some(info) = h.classify_node(node, source) {
-                        let vis = h.visibility(node, source);
-                        all_items.push(dispatch::node_to_item(node, source, h.as_ref(), info.kind, info.name, vis));
-                        found_by_handler.insert(name.clone());
-                    }
+                if let Some(node) =
+                    dispatch::find_symbol_node_by_query(source, tree, h.as_ref(), language, name)
+                    && let Some(info) = h.classify_node(node, source)
+                {
+                    let vis = h.visibility(node, source);
+                    all_items.push(dispatch::node_to_item(
+                        node,
+                        source,
+                        h.as_ref(),
+                        info.kind,
+                        info.name,
+                        vis,
+                    ));
+                    found_by_handler.insert(name.clone());
+                }
                 // Try unqualified member lookup via handler
                 if !found_by_handler.contains(name) {
-                    let mut items = dispatch::find_unqualified_member(source, tree, h.as_ref(), language, name);
+                    let mut items =
+                        dispatch::find_unqualified_member(source, tree, h.as_ref(), language, name);
                     if !items.is_empty() {
                         found_by_handler.insert(name.clone());
                         all_items.append(&mut items);
@@ -359,7 +389,10 @@ fn expand_with_dispatch(
         }
 
         // Fall back to expand query for anything not found by handler dispatch
-        let remaining: Vec<String> = simple.into_iter().filter(|s| !found_by_handler.contains(s)).collect();
+        let remaining: Vec<String> = simple
+            .into_iter()
+            .filter(|s| !found_by_handler.contains(s))
+            .collect();
         if !remaining.is_empty() {
             let mut fallback_items = extractor::expand::extract(source, tree, &remaining, language);
             all_items.append(&mut fallback_items);
@@ -381,12 +414,12 @@ fn process_file(
     outline: bool,
     compact: bool,
     expand_symbols: &[String],
+    with_comments: bool,
 ) -> Result<(Vec<Item>, usize, usize), CodehudError> {
-    let source = fs::read_to_string(path)
-        .map_err(|e| CodehudError::ReadError {
-            path: path.display().to_string(),
-            source: e,
-        })?;
+    let source = fs::read_to_string(path).map_err(|e| CodehudError::ReadError {
+        path: path.display().to_string(),
+        source: e,
+    })?;
 
     let lines = source.lines().count();
     let bytes = source.len();
@@ -398,7 +431,8 @@ fn process_file(
             // No script blocks found — fall through to passthrough
             if expand_mode {
                 return Err(CodehudError::ParseError(format!(
-                    "No script blocks found in SFC file: {}", path.display()
+                    "No script blocks found in SFC file: {}",
+                    path.display()
                 )));
             }
             let numbered = source
@@ -416,6 +450,7 @@ fn process_file(
                 content: numbered,
                 signature: None,
                 body: None,
+                doc_comment: None,
                 line_mappings: None,
             };
             return Ok((vec![item], lines, bytes));
@@ -425,17 +460,40 @@ fn process_file(
         for block in &blocks {
             let tree = parser::parse(&block.content, block.language)?;
             let mut block_items = if signatures && !symbols.is_empty() {
-                extractor::expand::extract_signatures(&block.content, &tree, &symbols[0], expand_methods, block.language)
+                extractor::expand::extract_signatures(
+                    &block.content,
+                    &tree,
+                    &symbols[0],
+                    expand_methods,
+                    block.language,
+                )
             } else if expand_mode {
                 expand_with_dispatch(&block.content, &tree, symbols, block.language)
             } else if outline {
-                let mut items = extractor::outline::extract_outline(&block.content, &tree, block.language, pub_only, compact);
+                let mut items = extractor::outline::extract_outline(
+                    &block.content,
+                    &tree,
+                    block.language,
+                    pub_only,
+                    compact,
+                );
                 if !expand_symbols.is_empty() {
-                    inline_expand_symbols(&mut items, &block.content, &tree, expand_symbols, block.language);
+                    inline_expand_symbols(
+                        &mut items,
+                        &block.content,
+                        &tree,
+                        expand_symbols,
+                        block.language,
+                    );
                 }
                 items
             } else {
-                extractor::interface::extract_filtered(&block.content, &tree, block.language, pub_only)
+                extractor::interface::extract_filtered(
+                    &block.content,
+                    &tree,
+                    block.language,
+                    pub_only,
+                )
             };
             // Adjust line numbers to map back to original SFC file
             let offset = block.start_line - 1;
@@ -477,6 +535,7 @@ fn process_file(
             content: numbered,
             signature: None,
             body: None,
+            doc_comment: None,
             line_mappings: None,
         };
         return Ok((vec![item], lines, bytes));
@@ -489,7 +548,10 @@ fn process_file(
         // For signatures mode with dot-notation, extract the class name
         let first = &symbols[0];
         let class_name = if first.contains('.') || first.contains("::") {
-            first.split(['.', ':']).find(|s| !s.is_empty()).unwrap_or(first)
+            first
+                .split(['.', ':'])
+                .find(|s| !s.is_empty())
+                .unwrap_or(first)
         } else {
             first.as_str()
         };
@@ -497,7 +559,8 @@ fn process_file(
     } else if expand_mode {
         expand_with_dispatch(&source, &tree, symbols, language)
     } else if outline {
-        let mut items = extractor::outline::extract_outline(&source, &tree, language, pub_only, compact);
+        let mut items =
+            extractor::outline::extract_outline(&source, &tree, language, pub_only, compact);
         if !expand_symbols.is_empty() {
             inline_expand_symbols(&mut items, &source, &tree, expand_symbols, language);
         }
@@ -506,5 +569,89 @@ fn process_file(
         extractor::interface::extract_filtered(&source, &tree, language, pub_only)
     };
 
+    // Populate doc comments if requested
+    let items = if with_comments {
+        let mut items = populate_doc_comments(items, &source, &tree, language);
+        // For expand mode, prepend doc comment to content
+        if expand_mode {
+            for item in &mut items {
+                if let Some(ref doc) = item.doc_comment {
+                    item.content = format!("{}\n{}", doc, item.content);
+                }
+            }
+        }
+        items
+    } else {
+        items
+    };
+
     Ok((items, lines, bytes))
+}
+
+/// Post-process items to populate doc_comment fields using language-aware extraction.
+fn populate_doc_comments(
+    mut items: Vec<Item>,
+    source: &str,
+    tree: &tree_sitter::Tree,
+    language: Language,
+) -> Vec<Item> {
+    let handler = match handler::handler_for(language) {
+        Some(h) => h,
+        None => return items,
+    };
+    let ts_lang = languages::ts_language(language);
+    let query = match tree_sitter::Query::new(&ts_lang, handler.symbol_query()) {
+        Ok(q) => q,
+        Err(_) => return items,
+    };
+
+    let mut cursor = tree_sitter::QueryCursor::new();
+    let source_bytes = source.as_bytes();
+    let item_idx = match query.capture_index_for_name("item") {
+        Some(idx) => idx,
+        None => return items,
+    };
+
+    // Build a map of line_start -> AST node for matching
+    use std::collections::HashMap;
+    let mut line_to_node: HashMap<usize, tree_sitter::Node> = HashMap::new();
+    use tree_sitter::StreamingIterator;
+    let mut matches_iter = cursor.matches(&query, tree.root_node(), source_bytes);
+    while let Some(m) = matches_iter.next() {
+        if let Some(cap) = m.captures.iter().find(|c| c.index == item_idx) {
+            let node = cap.node;
+            let line = node.start_position().row + 1;
+            line_to_node.entry(line).or_insert(node);
+
+            // Also index child symbols for containers
+            if let Some(info) = handler.classify_node(node, source)
+                && matches!(
+                    info.kind,
+                    ItemKind::Class | ItemKind::Impl | ItemKind::Trait
+                )
+            {
+                // Unwrap export wrapper
+                let inner = if node.kind() == "export_statement" {
+                    let mut walk = node.walk();
+                    node.named_children(&mut walk)
+                        .find(|c| c.kind() != "decorator" && c.kind() != "comment")
+                        .unwrap_or(node)
+                } else {
+                    node
+                };
+                for child in handler.child_symbols(inner, source) {
+                    let child_line = child.node.start_position().row + 1;
+                    line_to_node.entry(child_line).or_insert(child.node);
+                }
+            }
+        }
+    }
+
+    for item in &mut items {
+        if let Some(&node) = line_to_node.get(&item.line_start) {
+            item.doc_comment = handler.get_doc_comment(source, node);
+        }
+    }
+
+    items
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,17 @@
 use clap::{Parser, Subcommand};
-use codehud::{detect_language, editor, process_path, search, tokens, tree, ProcessOptions, OutputFormat, Language, CodehudError};
-use codehud::editor::{BatchEdit, EditResult};
 use codehud::agent;
+use codehud::editor::{BatchEdit, EditResult};
 use codehud::skill;
-use std::{fs, io::{self, IsTerminal, Read}, path::Path, process};
+use codehud::{
+    CodehudError, Language, OutputFormat, ProcessOptions, detect_language, editor, process_path,
+    search, tokens, tree,
+};
+use std::{
+    fs,
+    io::{self, IsTerminal, Read},
+    path::Path,
+    process,
+};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -13,27 +21,27 @@ use tracing_subscriber::EnvFilter;
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
-    
+
     /// File or directory to analyze
     #[arg(value_name = "PATH")]
     path: Option<String>,
-    
+
     /// Symbol names to expand (triggers expand mode)
     #[arg(value_name = "SYMBOLS")]
     symbols: Vec<String>,
-    
+
     /// Only public items
     #[arg(long = "pub")]
     pub_only: bool,
-    
+
     /// Only show functions/methods
     #[arg(long)]
     fns: bool,
-    
+
     /// Only show types (struct/enum/trait/type alias)
     #[arg(long)]
     types: bool,
-    
+
     /// Directory recursion depth (default: unlimited)
     #[arg(short = 'd', long)]
     depth: Option<usize>,
@@ -41,7 +49,7 @@ struct Cli {
     /// Smart depth for monorepos: auto-detect source roots and apply depth relative to them
     #[arg(long = "smart-depth")]
     smart_depth: bool,
-    
+
     /// JSON output instead of plain text
     #[arg(long)]
     json: bool,
@@ -53,7 +61,7 @@ struct Cli {
     /// Suppress token count footer
     #[arg(long = "no-footer", overrides_with = "footer")]
     no_footer: bool,
-    
+
     /// Exclude test code (Rust: #[cfg(test)]/​#[test], TS/JS: *.test.ts/describe()/it(), Python: test_*.py, Go: *_test.go)
     #[arg(long = "no-tests")]
     no_tests: bool,
@@ -65,7 +73,7 @@ struct Cli {
     /// Include imports in --list-symbols output (they are hidden by default)
     #[arg(long, requires = "list_symbols")]
     imports: bool,
-    
+
     /// Show stats summary (file count, lines, bytes, top dirs, languages)
     #[arg(long)]
     stats: bool,
@@ -170,6 +178,10 @@ struct Cli {
     #[arg(long)]
     staged: bool,
 
+    /// Include doc comments attached to symbols (works with expand mode and --list-symbols --json)
+    #[arg(long = "with-comments")]
+    with_comments: bool,
+
     /// Truncate final output after N lines (works with any mode)
     #[arg(long = "max-output-lines")]
     max_output_lines: Option<usize>,
@@ -251,51 +263,51 @@ enum Commands {
     Edit {
         /// File to edit
         file: String,
-        
+
         /// Symbol name to edit (not needed with --batch)
         #[arg(default_value = "")]
         symbol: String,
-        
+
         /// Replace the symbol with new source
         #[arg(long, conflicts_with_all = ["delete", "replace_body", "batch"])]
         replace: Option<String>,
-        
+
         /// Replace only the body block, preserving signature/attributes
         #[arg(long = "replace-body", conflicts_with_all = ["delete", "replace", "batch"])]
         replace_body: Option<String>,
-        
+
         /// Read replacement from stdin (works with --replace or --replace-body)
         #[arg(long)]
         stdin: bool,
-        
+
         /// Delete the symbol
         #[arg(long, conflicts_with_all = ["replace", "replace_body", "batch"])]
         delete: bool,
-        
+
         /// Insert new code after a named symbol
         #[arg(long = "add-after", conflicts_with_all = ["replace", "replace_body", "delete", "add_before", "append", "prepend", "batch"])]
         add_after: Option<String>,
-        
+
         /// Insert new code before a named symbol
         #[arg(long = "add-before", conflicts_with_all = ["replace", "replace_body", "delete", "add_after", "append", "prepend", "batch"])]
         add_before: Option<String>,
-        
+
         /// Append new code to end of file
         #[arg(long, conflicts_with_all = ["replace", "replace_body", "delete", "add_after", "add_before", "prepend", "batch"])]
         append: bool,
-        
+
         /// Prepend new code at beginning of file (after leading comments)
         #[arg(long, conflicts_with_all = ["replace", "replace_body", "delete", "add_after", "add_before", "append", "batch"])]
         prepend: bool,
-        
+
         /// Apply batch edits from a JSON file
         #[arg(long, conflicts_with_all = ["replace", "replace_body", "delete", "add_after", "add_before", "append", "prepend"])]
         batch: Option<String>,
-        
+
         /// Dry run - print to stdout instead of writing file
         #[arg(long)]
         dry_run: bool,
-        
+
         /// Output JSON metadata about what changed
         #[arg(long)]
         json: bool,
@@ -309,12 +321,21 @@ fn looks_like_symbol(pattern: &str) -> bool {
     !pattern.is_empty()
         && !pattern.contains(char::is_whitespace)
         && pattern.chars().all(|c| c.is_alphanumeric() || c == '_')
-        && pattern.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_')
+        && pattern
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphabetic() || c == '_')
 }
 
 /// Print output with optional token count footer.
 /// For JSON output, injects token_estimate and cost_estimate into the top-level object.
-fn emit_output(output: &str, max_lines: Option<usize>, json: bool, show_footer: bool, token_budget: Option<usize>) {
+fn emit_output(
+    output: &str,
+    max_lines: Option<usize>,
+    json: bool,
+    show_footer: bool,
+    token_budget: Option<usize>,
+) {
     let truncated = final_output(output, max_lines, token_budget, json);
     let token_count = tokens::estimate_tokens(&truncated);
     let cost = tokens::estimate_cost(token_count, true);
@@ -324,9 +345,15 @@ fn emit_output(output: &str, max_lines: Option<usize>, json: bool, show_footer: 
         if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&truncated) {
             if let Some(obj) = value.as_object_mut() {
                 obj.insert("token_estimate".to_string(), serde_json::json!(token_count));
-                obj.insert("cost_estimate".to_string(), serde_json::json!(format!("{:.4}", cost)));
+                obj.insert(
+                    "cost_estimate".to_string(),
+                    serde_json::json!(format!("{:.4}", cost)),
+                );
             }
-            print!("{}", serde_json::to_string_pretty(&value).unwrap_or(truncated.clone()));
+            print!(
+                "{}",
+                serde_json::to_string_pretty(&value).unwrap_or(truncated.clone())
+            );
         } else {
             print!("{}", truncated);
         }
@@ -335,7 +362,10 @@ fn emit_output(output: &str, max_lines: Option<usize>, json: bool, show_footer: 
     }
 
     if show_footer {
-        eprintln!("[Output: {} tokens | ~${:.2} with caching]", token_count, cost);
+        eprintln!(
+            "[Output: {} tokens | ~${:.2} with caching]",
+            token_count, cost
+        );
     }
 }
 
@@ -350,11 +380,19 @@ fn truncate_output(output: &str, max_lines: Option<usize>) -> String {
     }
     let mut result: String = output.lines().take(max).collect::<Vec<_>>().join("\n");
     result.push('\n');
-    result.push_str(&format!("[Output truncated: {} lines shown of {} total]\n", max, total));
+    result.push_str(&format!(
+        "[Output truncated: {} lines shown of {} total]\n",
+        max, total
+    ));
     result
 }
 
-fn final_output(output: &str, max_lines: Option<usize>, budget: Option<usize>, json: bool) -> String {
+fn final_output(
+    output: &str,
+    max_lines: Option<usize>,
+    budget: Option<usize>,
+    json: bool,
+) -> String {
     let truncated = truncate_output(output, max_lines);
     match budget {
         Some(b) => tokens::truncate_to_token_budget(&truncated, b, json),
@@ -400,16 +438,21 @@ fn main() {
     };
     let token_budget = cli.token_budget;
     let is_json = cli.json;
-    
+
     match cli.command {
-        Some(Commands::InstallSkill { platform, list, global }) => {
+        Some(Commands::InstallSkill {
+            platform,
+            list,
+            global,
+        }) => {
             if list {
                 skill::list_platforms();
             } else if let Some(p) = platform
-                && let Err(e) = skill::install(&p, global) {
-                    eprintln!("Error: {}", e);
-                    process::exit(1);
-                }
+                && let Err(e) = skill::install(&p, global)
+            {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
         }
         Some(Commands::UninstallSkill { platform, global }) => {
             if let Err(e) = skill::uninstall(&platform, global) {
@@ -421,10 +464,11 @@ fn main() {
             if list {
                 agent::list_platforms();
             } else if let Some(p) = platform
-                && let Err(e) = agent::install(&p) {
-                    eprintln!("Error: {}", e);
-                    process::exit(1);
-                }
+                && let Err(e) = agent::install(&p)
+            {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
         }
         Some(Commands::UninstallAgent { platform, force }) => {
             if let Err(e) = agent::uninstall(&platform, force) {
@@ -432,8 +476,38 @@ fn main() {
                 process::exit(1);
             }
         }
-        Some(Commands::Edit { file, symbol, replace, replace_body, stdin, delete, add_after, add_before, append, prepend, batch, dry_run, json }) => {
-            if let Err(e) = handle_edit(&file, &symbol, EditOptions { replace, replace_body, stdin, delete, add_after, add_before, append, prepend, batch, dry_run, json }) {
+        Some(Commands::Edit {
+            file,
+            symbol,
+            replace,
+            replace_body,
+            stdin,
+            delete,
+            add_after,
+            add_before,
+            append,
+            prepend,
+            batch,
+            dry_run,
+            json,
+        }) => {
+            if let Err(e) = handle_edit(
+                &file,
+                &symbol,
+                EditOptions {
+                    replace,
+                    replace_body,
+                    stdin,
+                    delete,
+                    add_after,
+                    add_before,
+                    append,
+                    prepend,
+                    batch,
+                    dry_run,
+                    json,
+                },
+            ) {
                 eprintln!("Error: {}", e);
                 process::exit(1);
             }
@@ -471,7 +545,13 @@ fn main() {
                 };
                 match result {
                     Ok(output) => {
-                        emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                        emit_output(
+                            &output,
+                            max_output_lines,
+                            is_json,
+                            show_footer,
+                            token_budget,
+                        );
                     }
                     Err(e) => {
                         eprintln!("Error: {}", e);
@@ -485,7 +565,13 @@ fn main() {
             if let Some(lines_arg) = cli.lines {
                 match codehud::extract_lines(&path, &lines_arg, cli.json) {
                     Ok(output) => {
-                        emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                        emit_output(
+                            &output,
+                            max_output_lines,
+                            is_json,
+                            show_footer,
+                            token_budget,
+                        );
                     }
                     Err(e) => {
                         eprintln!("Error: {}", e);
@@ -525,11 +611,25 @@ fn main() {
                 match result {
                     Ok(refs) => {
                         if cli.json {
-                            let output = codehud::references::format_json(&refs); emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                            let output = codehud::references::format_json(&refs);
+                            emit_output(
+                                &output,
+                                max_output_lines,
+                                is_json,
+                                show_footer,
+                                token_budget,
+                            );
                         } else {
-                            let output = codehud::references::format_plain(&refs); emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
-                    }
+                            let output = codehud::references::format_plain(&refs);
+                            emit_output(
+                                &output,
+                                max_output_lines,
+                                is_json,
+                                show_footer,
+                                token_budget,
+                            );
                         }
+                    }
                     Err(e) => {
                         eprintln!("Error: {}", e);
                         process::exit(1);
@@ -552,9 +652,23 @@ fn main() {
                 match codehud::xrefs::find_xrefs(&path, &xref_opts) {
                     Ok(refs) => {
                         if cli.json {
-                            let output = codehud::references::format_json(&refs); emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                            let output = codehud::references::format_json(&refs);
+                            emit_output(
+                                &output,
+                                max_output_lines,
+                                is_json,
+                                show_footer,
+                                token_budget,
+                            );
                         } else {
-                            let output = codehud::references::format_plain(&refs); emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                            let output = codehud::references::format_plain(&refs);
+                            emit_output(
+                                &output,
+                                max_output_lines,
+                                is_json,
+                                show_footer,
+                                token_budget,
+                            );
                         }
                     }
                     Err(e) => {
@@ -585,7 +699,13 @@ fn main() {
                 };
                 match codehud::diff_cli::run_diff(&diff_opts) {
                     Ok(output) => {
-                        emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                        emit_output(
+                            &output,
+                            max_output_lines,
+                            is_json,
+                            show_footer,
+                            token_budget,
+                        );
                     }
                     Err(e) => {
                         eprintln!("Error: {}", e);
@@ -605,11 +725,19 @@ fn main() {
                     case_insensitive: cli.case_insensitive,
                     depth: cli.depth,
                     ext: cli.ext,
-                    max_results: cli.limit.or(cli.max_results).or(if is_dir { Some(20) } else { None }),
+                    max_results: cli.limit.or(cli.max_results).or(if is_dir {
+                        Some(20)
+                    } else {
+                        None
+                    }),
                     no_tests: cli.no_tests,
                     exclude: cli.exclude,
                     json: cli.json,
-                    context: if cli.context > 0 { Some(cli.context) } else { None },
+                    context: if cli.context > 0 {
+                        Some(cli.context)
+                    } else {
+                        None
+                    },
                     summary: cli.summary,
                     files_first: cli.files_first,
                 };
@@ -619,10 +747,19 @@ fn main() {
                         process::exit(1);
                     }
                     Ok(output) => {
-                        emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                        emit_output(
+                            &output,
+                            max_output_lines,
+                            is_json,
+                            show_footer,
+                            token_budget,
+                        );
                         // Show xrefs hint for symbol-like patterns in non-JSON mode
                         if !cli.json && looks_like_symbol(&pattern_display) {
-                            eprintln!("\n💡 Tip: For symbol definitions and references, try: codehud --xrefs {}", pattern_display);
+                            eprintln!(
+                                "\n💡 Tip: For symbol definitions and references, try: codehud --xrefs {}",
+                                pattern_display
+                            );
                         }
                     }
                     Err(e) => {
@@ -632,13 +769,13 @@ fn main() {
                 }
                 return;
             }
-            
+
             let format = if cli.json {
                 OutputFormat::Json
             } else {
                 OutputFormat::Plain
             };
-            
+
             // When --smart-depth is used without --depth, default to depth 0
             // so smart-depth can discover source roots and walk into them
             let effective_depth = if cli.smart_depth && cli.depth.is_none() {
@@ -673,13 +810,22 @@ fn main() {
                 minimal: cli.minimal,
                 expand_symbols: cli.expand_symbols,
                 yes: cli.yes,
-                warn_threshold: cli.warn_threshold.unwrap_or(codehud::walk::DEFAULT_WARN_THRESHOLD),
+                warn_threshold: cli
+                    .warn_threshold
+                    .unwrap_or(codehud::walk::DEFAULT_WARN_THRESHOLD),
                 token_budget: cli.token_budget,
+                with_comments: cli.with_comments,
             };
-            
+
             match process_path(&path, options) {
                 Ok(output) => {
-                    emit_output(&output, max_output_lines, is_json, show_footer, token_budget);
+                    emit_output(
+                        &output,
+                        max_output_lines,
+                        is_json,
+                        show_footer,
+                        token_budget,
+                    );
                 }
                 Err(e) => {
                     eprintln!("Error: {}", e);
@@ -704,47 +850,57 @@ struct EditOptions {
     json: bool,
 }
 
-fn handle_edit(
-    file: &str,
-    symbol: &str,
-    opts: EditOptions,
-) -> Result<(), CodehudError> {
-    let EditOptions { replace, replace_body, stdin, delete, add_after, add_before, append, prepend, batch, dry_run, json } = opts;
+fn handle_edit(file: &str, symbol: &str, opts: EditOptions) -> Result<(), CodehudError> {
+    let EditOptions {
+        replace,
+        replace_body,
+        stdin,
+        delete,
+        add_after,
+        add_before,
+        append,
+        prepend,
+        batch,
+        dry_run,
+        json,
+    } = opts;
     let path = Path::new(file);
     if !path.exists() {
         return Err(CodehudError::PathNotFound(file.to_string()));
     }
-    
-    let source = fs::read_to_string(path)
-        .map_err(|e| CodehudError::ReadError {
-            path: file.to_string(),
-            source: e,
-        })?;
-    
+
+    let source = fs::read_to_string(path).map_err(|e| CodehudError::ReadError {
+        path: file.to_string(),
+        source: e,
+    })?;
+
     let language_opt = detect_language(path).ok();
-    
+
     // For AST-based operations, we need a language. For simple ops (append/prepend), we don't.
     let require_language = |op: &str| -> Result<Language, CodehudError> {
-        language_opt.ok_or_else(|| CodehudError::ParseError(format!(
-            "{} requires a supported language (rs/ts/tsx/js/jsx/py) for AST operations. \
+        language_opt.ok_or_else(|| {
+            CodehudError::ParseError(format!(
+                "{} requires a supported language (rs/ts/tsx/js/jsx/py) for AST operations. \
              For unsupported file types, use --append or --prepend instead.",
-            op
-        )))
+                op
+            ))
+        })
     };
-    
+
     // Compute edit metadata before performing the edit (line ranges from original source)
     let mut edit_results: Vec<EditResult> = Vec::new();
-    
+
     let result = if let Some(batch_file) = batch {
-        let batch_json = fs::read_to_string(&batch_file)
-            .map_err(|e| CodehudError::ReadError {
-                path: batch_file.clone(),
-                source: e,
-            })?;
+        let batch_json = fs::read_to_string(&batch_file).map_err(|e| CodehudError::ReadError {
+            path: batch_file.clone(),
+            source: e,
+        })?;
         #[derive(serde::Deserialize)]
-        struct BatchInput { edits: Vec<BatchEdit> }
+        struct BatchInput {
+            edits: Vec<BatchEdit>,
+        }
         let input: BatchInput = serde_json::from_str(&batch_json)?;
-        
+
         let language = require_language("batch edit")?;
         if json {
             for edit in &input.edits {
@@ -769,7 +925,7 @@ fn handle_edit(
                 });
             }
         }
-        
+
         editor::batch(&source, &input.edits, language)?
     } else if delete {
         let language = require_language("--delete")?;
@@ -787,7 +943,8 @@ fn handle_edit(
         let language = require_language("--replace-body")?;
         let new_body = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -807,7 +964,8 @@ fn handle_edit(
         let language = require_language("--replace")?;
         let new_content = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -827,7 +985,8 @@ fn handle_edit(
         let language = require_language("--add-after")?;
         let new_code = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -846,7 +1005,8 @@ fn handle_edit(
         let language = require_language("--add-before")?;
         let new_code = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -864,7 +1024,8 @@ fn handle_edit(
     } else if append {
         let new_code = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -898,7 +1059,8 @@ fn handle_edit(
     } else if prepend {
         let new_code = if stdin {
             let mut buf = String::new();
-            io::stdin().read_to_string(&mut buf)
+            io::stdin()
+                .read_to_string(&mut buf)
                 .map_err(|e| CodehudError::ParseError(format!("Failed to read stdin: {}", e)))?;
             buf
         } else {
@@ -932,17 +1094,16 @@ fn handle_edit(
             "Must specify --replace, --replace-body, --delete, --add-after, --add-before, --append, --prepend, or --batch".to_string()
         ));
     };
-    
+
     if dry_run {
         print!("{}", result);
     } else {
-        fs::write(path, &result)
-            .map_err(|e| CodehudError::ReadError {
-                path: file.to_string(),
-                source: e,
-            })?;
+        fs::write(path, &result).map_err(|e| CodehudError::ReadError {
+            path: file.to_string(),
+            source: e,
+        })?;
     }
-    
+
     if json {
         if edit_results.len() == 1 {
             println!("{}", serde_json::to_string(&edit_results[0])?);
@@ -950,11 +1111,9 @@ fn handle_edit(
             println!("{}", serde_json::to_string(&edit_results)?);
         }
     }
-    
+
     Ok(())
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -990,7 +1149,10 @@ mod tests {
         let cost = codehud::tokens::estimate_cost(token_count, true);
         let mut obj = value.as_object().unwrap().clone();
         obj.insert("token_estimate".to_string(), serde_json::json!(token_count));
-        obj.insert("cost_estimate".to_string(), serde_json::json!(format!("{:.4}", cost)));
+        obj.insert(
+            "cost_estimate".to_string(),
+            serde_json::json!(format!("{:.4}", cost)),
+        );
         assert!(obj.contains_key("token_estimate"));
         assert!(obj.contains_key("cost_estimate"));
         assert_eq!(obj["token_estimate"], serde_json::json!(token_count));
@@ -1001,13 +1163,25 @@ mod tests {
         // --no-footer always suppresses
         let no_footer = true;
         let footer = false;
-        let show = if no_footer { false } else if footer { true } else { false };
+        let show = if no_footer {
+            false
+        } else if footer {
+            true
+        } else {
+            false
+        };
         assert!(!show);
 
         // --footer always enables
         let no_footer = false;
         let footer = true;
-        let show = if no_footer { false } else if footer { true } else { false };
+        let show = if no_footer {
+            false
+        } else if footer {
+            true
+        } else {
+            false
+        };
         assert!(show);
     }
 }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -29,6 +29,8 @@ struct JsonItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     body: Option<String>,
     content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    doc_comment: Option<String>,
 }
 
 /// Format list-symbols output as JSON: array of {kind, name, line} per file
@@ -40,6 +42,8 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
         line: usize,
         line_end: usize,
         visibility: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        doc_comment: Option<String>,
     }
 
     #[derive(Serialize)]
@@ -52,12 +56,10 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
         .iter()
         .filter(|(_, items)| !items.is_empty())
         .map(|(path, items)| {
-            let lang = detect_language(Path::new(path))
-                .ok()
-                .or_else(|| {
-                    crate::sfc::detect_sfc(Path::new(path))
-                        .map(|_| crate::languages::Language::TypeScript)
-                });
+            let lang = detect_language(Path::new(path)).ok().or_else(|| {
+                crate::sfc::detect_sfc(Path::new(path))
+                    .map(|_| crate::languages::Language::TypeScript)
+            });
             let symbols = items
                 .iter()
                 .map(|item| {
@@ -71,6 +73,7 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
                         line: item.line_start,
                         line_end: item.line_end,
                         visibility: format!("{:?}", item.visibility).to_lowercase(),
+                        doc_comment: item.doc_comment.clone(),
                     }
                 })
                 .collect();
@@ -99,12 +102,10 @@ pub fn format_output(files: &[(String, Vec<Item>)]) -> Result<String, CodehudErr
     let files_output: Vec<FileOutput> = files
         .iter()
         .map(|(path, items)| {
-            let lang = detect_language(Path::new(path))
-                .ok()
-                .or_else(|| {
-                    crate::sfc::detect_sfc(Path::new(path))
-                        .map(|_| crate::languages::Language::TypeScript)
-                });
+            let lang = detect_language(Path::new(path)).ok().or_else(|| {
+                crate::sfc::detect_sfc(Path::new(path))
+                    .map(|_| crate::languages::Language::TypeScript)
+            });
             let json_items: Vec<JsonItem> = items
                 .iter()
                 .map(|item| JsonItem {
@@ -119,6 +120,7 @@ pub fn format_output(files: &[(String, Vec<Item>)]) -> Result<String, CodehudErr
                     signature: item.signature.clone(),
                     body: item.body.clone(),
                     content: item.content.clone(),
+                    doc_comment: item.doc_comment.clone(),
                 })
                 .collect();
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,5 +1,5 @@
-pub mod plain;
 pub mod json;
+pub mod plain;
 pub mod stats;
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -4,7 +4,11 @@ use crate::languages::{Language, detect_language};
 use std::path::Path;
 
 /// Format items as plain text with line numbers
-pub fn format_output(files: &[(String, Vec<Item>)], expand_mode: bool, max_lines: Option<usize>) -> Result<String, CodehudError> {
+pub fn format_output(
+    files: &[(String, Vec<Item>)],
+    expand_mode: bool,
+    max_lines: Option<usize>,
+) -> Result<String, CodehudError> {
     let mut output = String::new();
 
     for (file_path, items) in files {
@@ -66,13 +70,11 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
     for (file_path, items) in files {
         writeln!(output, "{}", file_path).unwrap();
 
-        let lang = detect_language(Path::new(file_path))
-            .ok()
-            .or_else(|| {
-                // For SFC files (Vue/Svelte/Astro), fall back to TypeScript for display names
-                crate::sfc::detect_sfc(Path::new(file_path))
-                    .map(|_| crate::languages::Language::TypeScript)
-            });
+        let lang = detect_language(Path::new(file_path)).ok().or_else(|| {
+            // For SFC files (Vue/Svelte/Astro), fall back to TypeScript for display names
+            crate::sfc::detect_sfc(Path::new(file_path))
+                .map(|_| crate::languages::Language::TypeScript)
+        });
 
         let mut current_class_end: Option<usize> = None;
         for item in items {
@@ -81,13 +83,29 @@ pub fn format_list_symbols(files: &[(String, Vec<Item>)]) -> Result<String, Code
             // Indent methods that fall within a class range
             let is_member = matches!(item.kind, crate::extractor::ItemKind::Method)
                 && current_class_end.is_some_and(|end| item.line_start <= end);
-            if matches!(item.kind, crate::extractor::ItemKind::Class | crate::extractor::ItemKind::Struct | crate::extractor::ItemKind::Trait | crate::extractor::ItemKind::Impl) {
+            if matches!(
+                item.kind,
+                crate::extractor::ItemKind::Class
+                    | crate::extractor::ItemKind::Struct
+                    | crate::extractor::ItemKind::Trait
+                    | crate::extractor::ItemKind::Impl
+            ) {
                 current_class_end = Some(item.line_end);
             }
             if is_member {
-                writeln!(output, "    {:<10} {:<28} L{}", kind_label, name, item.line_start).unwrap();
+                writeln!(
+                    output,
+                    "    {:<10} {:<28} L{}",
+                    kind_label, name, item.line_start
+                )
+                .unwrap();
             } else {
-                writeln!(output, "  {:<10} {:<30} L{}", kind_label, name, item.line_start).unwrap();
+                writeln!(
+                    output,
+                    "  {:<10} {:<30} L{}",
+                    kind_label, name, item.line_start
+                )
+                .unwrap();
             }
         }
     }
@@ -141,7 +159,12 @@ fn format_item(item: &Item) -> String {
     // Use explicit line mappings if available (for interface mode with collapsed bodies)
     if let Some(ref mappings) = item.line_mappings {
         for (line_num, line_text) in mappings {
-            result.push_str(&format!("{:>width$} | {}\n", line_num, line_text, width = width));
+            result.push_str(&format!(
+                "{:>width$} | {}\n",
+                line_num,
+                line_text,
+                width = width
+            ));
         }
     } else {
         // Default: sequential line numbers (for expand mode)
@@ -154,7 +177,6 @@ fn format_item(item: &Item) -> String {
 
     result
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -171,6 +193,7 @@ mod tests {
             signature: None,
             body: None,
             content: content.to_string(),
+            doc_comment: None,
             line_mappings: None,
         }
     }
@@ -187,9 +210,7 @@ mod tests {
     #[test]
     fn format_item_with_line_mappings() {
         let mut item = make_item("foo", "", 1, 5);
-        item.line_mappings = Some(vec![
-            (1, "fn foo() { ... }".to_string()),
-        ]);
+        item.line_mappings = Some(vec![(1, "fn foo() { ... }".to_string())]);
         let result = format_item(&item);
         assert!(result.contains("1 | fn foo() { ... }"));
     }

--- a/src/output/stats.rs
+++ b/src/output/stats.rs
@@ -1,7 +1,7 @@
+use super::OutputFormat;
 use crate::error::CodehudError;
 use crate::extractor::Item;
 use crate::languages::detect_language;
-use super::OutputFormat;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::path::Path;
@@ -52,7 +52,13 @@ fn gather_stats(
         })
         .collect();
 
-    (file_stats, total_lines, total_bytes, total_items, total_kinds)
+    (
+        file_stats,
+        total_lines,
+        total_bytes,
+        total_items,
+        total_kinds,
+    )
 }
 
 /// Format stats output in the requested format.
@@ -77,10 +83,17 @@ fn format_plain(
         gather_stats(files, source_sizes);
 
     let mut out = String::new();
-    let file_count = file_stats.iter().filter(|f| f.items > 0 || file_stats.len() == 1).count();
+    let file_count = file_stats
+        .iter()
+        .filter(|f| f.items > 0 || file_stats.len() == 1)
+        .count();
 
-    writeln!(out, "Files: {}  Lines: {}  Bytes: {}  Items: {}",
-        file_count, total_lines, total_bytes, total_items).unwrap();
+    writeln!(
+        out,
+        "Files: {}  Lines: {}  Bytes: {}  Items: {}",
+        file_count, total_lines, total_bytes, total_items
+    )
+    .unwrap();
 
     if !total_kinds.is_empty() {
         let kinds_str: Vec<String> = total_kinds
@@ -96,12 +109,21 @@ fn format_plain(
             if f.items == 0 {
                 continue;
             }
-            let kinds_str: Vec<String> = f.kinds
+            let kinds_str: Vec<String> = f
+                .kinds
                 .iter()
                 .map(|(k, v)| format!("{} {}", v, k))
                 .collect();
-            writeln!(out, "  {} — {} lines, {} bytes, {} items ({})",
-                f.path, f.lines, f.bytes, f.items, kinds_str.join(", ")).unwrap();
+            writeln!(
+                out,
+                "  {} — {} lines, {} bytes, {} items ({})",
+                f.path,
+                f.lines,
+                f.bytes,
+                f.items,
+                kinds_str.join(", ")
+            )
+            .unwrap();
         }
     } else if file_stats.len() > 1000 && summary_only {
         writeln!(out, "\n[Use --stats-detailed for full file list]").unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use tree_sitter::{Parser, Tree};
 /// Parse source code into a Tree-sitter AST
 pub fn parse(source: &str, language: Language) -> Result<Tree, CodehudError> {
     let mut parser = Parser::new();
-    
+
     let ts_language = languages::ts_language(language);
 
     parser
@@ -16,7 +16,6 @@ pub fn parse(source: &str, language: Language) -> Result<Tree, CodehudError> {
         .parse(source, None)
         .ok_or_else(|| CodehudError::ParseError("Failed to parse source code".to_string()))
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::error::CodehudError;
 use crate::extractor::{Item, ItemKind};
 use crate::output::OutputFormat;
-use crate::{languages, test_detect, walk, output, process_file, ProcessOptions};
+use crate::{ProcessOptions, languages, output, process_file, test_detect, walk};
 
 use std::collections::BTreeMap;
 
@@ -31,13 +31,27 @@ pub(crate) fn collect_and_extract(
     let expand_mode = !options.symbols.is_empty();
 
     let (symbols, expand_methods) = if options.signatures && options.symbols.len() > 1 {
-        (vec![options.symbols[0].clone()], options.symbols[1..].to_vec())
+        (
+            vec![options.symbols[0].clone()],
+            options.symbols[1..].to_vec(),
+        )
     } else {
         (options.symbols.clone(), Vec::new())
     };
 
     if path.is_file() {
-        let (items, lines, bytes) = process_file(path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact, &options.expand_symbols)?;
+        let (items, lines, bytes) = process_file(
+            path,
+            &symbols,
+            expand_mode,
+            options.signatures,
+            &expand_methods,
+            options.pub_only,
+            options.outline,
+            options.compact,
+            &options.expand_symbols,
+            options.with_comments,
+        )?;
         return Ok(vec![FileItems {
             path: path.to_string_lossy().to_string(),
             items,
@@ -67,7 +81,18 @@ pub(crate) fn collect_and_extract(
         if options.no_tests && test_detect::is_test_file_any_language(&file_path) {
             continue;
         }
-        match process_file(&file_path, &symbols, expand_mode, options.signatures, &expand_methods, options.pub_only, options.outline, options.compact, &options.expand_symbols) {
+        match process_file(
+            &file_path,
+            &symbols,
+            expand_mode,
+            options.signatures,
+            &expand_methods,
+            options.pub_only,
+            options.outline,
+            options.compact,
+            &options.expand_symbols,
+            options.with_comments,
+        ) {
             Ok((items, lines, bytes)) => {
                 if expand_mode && !items.is_empty() {
                     for item in &items {
@@ -192,7 +217,8 @@ fn language_label(path: &Path) -> String {
             languages::Language::Cpp => "C++",
             languages::Language::CSharp => "C#",
             languages::Language::Kotlin => "Kotlin",
-        }.to_string()
+        }
+        .to_string()
     } else {
         path.extension()
             .and_then(|e| e.to_str())
@@ -211,7 +237,9 @@ fn format_count(n: usize) -> String {
         let s = n.to_string();
         let mut result = String::new();
         for (i, c) in s.chars().rev().enumerate() {
-            if i > 0 && i % 3 == 0 { result.push(','); }
+            if i > 0 && i % 3 == 0 {
+                result.push(',');
+            }
             result.push(c);
         }
         result.chars().rev().collect()
@@ -262,20 +290,28 @@ pub(crate) fn format_stats_fast(
     match format {
         OutputFormat::Plain => {
             let mut out = String::new();
-            writeln!(out, "Files: {} | Dirs: {} | Lines: {} | Bytes: {} | Tokens: ~{}",
-                format_count(total_files), format_count(total_dirs),
-                format_count(total_lines), format_count(total_bytes),
-                format_count(total_tokens)).unwrap();
+            writeln!(
+                out,
+                "Files: {} | Dirs: {} | Lines: {} | Bytes: {} | Tokens: ~{}",
+                format_count(total_files),
+                format_count(total_dirs),
+                format_count(total_lines),
+                format_count(total_bytes),
+                format_count(total_tokens)
+            )
+            .unwrap();
             if !lang_counts.is_empty() {
                 let mut langs: Vec<(&String, &usize)> = lang_counts.iter().collect();
                 langs.sort_by(|a, b| b.1.cmp(a.1));
-                let lang_strs: Vec<String> = langs.iter()
+                let lang_strs: Vec<String> = langs
+                    .iter()
                     .map(|(k, v)| format!("{} ({})", k, format_count(**v)))
                     .collect();
                 writeln!(out, "  Languages: {}", lang_strs.join(", ")).unwrap();
             }
             if !top_dirs.is_empty() && total_dirs > 1 {
-                let dir_strs: Vec<String> = top_dirs.iter()
+                let dir_strs: Vec<String> = top_dirs
+                    .iter()
                     .map(|(d, c)| format!("{} ({})", d, c))
                     .collect();
                 writeln!(out, "  Top dirs: {}", dir_strs.join(", ")).unwrap();
@@ -283,7 +319,12 @@ pub(crate) fn format_stats_fast(
             if !summary_only && file_stats.len() > 1 {
                 writeln!(out).unwrap();
                 for f in file_stats {
-                    writeln!(out, "  {} — {} lines, {} bytes [{}]", f.path, f.lines, f.bytes, f.language).unwrap();
+                    writeln!(
+                        out,
+                        "  {} — {} lines, {} bytes [{}]",
+                        f.path, f.lines, f.bytes, f.language
+                    )
+                    .unwrap();
                 }
             } else if file_stats.len() > 1 && is_large {
                 writeln!(out, "\n[Use --stats-detailed for full file list]").unwrap();
@@ -302,19 +343,51 @@ pub(crate) fn format_stats_fast(
                 per_file: Vec<FileStat>,
             }
             #[derive(Serialize)]
-            struct LangStat { files: usize, lines: usize }
+            struct LangStat {
+                files: usize,
+                lines: usize,
+            }
             #[derive(Serialize)]
-            struct FileStat { path: String, lines: usize, bytes: usize, language: String }
+            struct FileStat {
+                path: String,
+                lines: usize,
+                bytes: usize,
+                language: String,
+            }
 
-            let languages: BTreeMap<String, LangStat> = lang_counts.into_iter()
-                .map(|(k, v)| (k.clone(), LangStat { files: v, lines: lang_lines[&k] }))
+            let languages: BTreeMap<String, LangStat> = lang_counts
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        LangStat {
+                            files: v,
+                            lines: lang_lines[&k],
+                        },
+                    )
+                })
                 .collect();
-            let per_file = if summary_only { vec![] } else {
-                file_stats.iter().map(|f| FileStat {
-                    path: f.path.clone(), lines: f.lines, bytes: f.bytes, language: f.language.clone()
-                }).collect()
+            let per_file = if summary_only {
+                vec![]
+            } else {
+                file_stats
+                    .iter()
+                    .map(|f| FileStat {
+                        path: f.path.clone(),
+                        lines: f.lines,
+                        bytes: f.bytes,
+                        language: f.language.clone(),
+                    })
+                    .collect()
             };
-            let output = StatsOut { files: total_files, lines: total_lines, bytes: total_bytes, tokens_approx: total_tokens, languages, per_file };
+            let output = StatsOut {
+                files: total_files,
+                lines: total_lines,
+                bytes: total_bytes,
+                tokens_approx: total_tokens,
+                languages,
+                per_file,
+            };
             Ok(serde_json::to_string_pretty(&output)?)
         }
     }
@@ -338,13 +411,15 @@ pub(crate) fn apply_filters(
                 None
             };
 
-            let filtered_items = fi.items
+            let filtered_items = fi
+                .items
                 .into_iter()
                 .filter(|item| {
                     if let Some(ref det) = detector
-                        && det.is_test_item(item) {
-                            return false;
-                        }
+                        && det.is_test_item(item)
+                    {
+                        return false;
+                    }
                     if options.pub_only && !item.is_public() {
                         return false;
                     }
@@ -355,12 +430,22 @@ pub(crate) fn apply_filters(
                         let is_fn = matches!(item.kind, ItemKind::Function | ItemKind::Method);
                         let is_type = matches!(
                             item.kind,
-                            ItemKind::Struct | ItemKind::Enum | ItemKind::Trait | ItemKind::TypeAlias | ItemKind::Class
+                            ItemKind::Struct
+                                | ItemKind::Enum
+                                | ItemKind::Trait
+                                | ItemKind::TypeAlias
+                                | ItemKind::Class
                         );
                         let mut matched = false;
-                        if options.fns_only && is_fn { matched = true; }
-                        if options.types_only && is_type { matched = true; }
-                        if !matched { return false; }
+                        if options.fns_only && is_fn {
+                            matched = true;
+                        }
+                        if options.types_only && is_type {
+                            matched = true;
+                        }
+                        if !matched {
+                            return false;
+                        }
                         if matches!(item.kind, ItemKind::Method) && !options.fns_only {
                             return false;
                         }
@@ -391,7 +476,12 @@ pub(crate) fn format_output(
     let expand_mode = !options.symbols.is_empty();
 
     if options.stats {
-        output::stats::format_output(filtered, source_sizes, options.format, !options.stats_detailed)
+        output::stats::format_output(
+            filtered,
+            source_sizes,
+            options.format,
+            !options.stats_detailed,
+        )
     } else if options.outline {
         match options.format {
             OutputFormat::Json => output::json::format_output(filtered),
@@ -409,11 +499,11 @@ pub(crate) fn format_output(
                 OutputFormat::Plain => output::plain::format_list_symbols(filtered),
             }
         }
-
-
     } else {
         match options.format {
-            OutputFormat::Plain => output::plain::format_output(filtered, expand_mode, options.max_lines),
+            OutputFormat::Plain => {
+                output::plain::format_output(filtered, expand_mode, options.max_lines)
+            }
             OutputFormat::Json => output::json::format_output(filtered),
         }
     }
@@ -434,6 +524,7 @@ mod tests {
             content: String::new(),
             signature: None,
             body: None,
+            doc_comment: None,
             line_mappings: None,
         }
     }
@@ -455,15 +546,16 @@ mod tests {
             list_symbols: false,
             no_imports: false,
             smart_depth: false,
-        symbol_depth: None,
-        exclude: vec![],
-        outline: false,
-        compact: false,
-        minimal: false,
-        expand_symbols: vec![],
-        yes: false,
-        warn_threshold: 10_000,
-        token_budget: None,
+            symbol_depth: None,
+            exclude: vec![],
+            outline: false,
+            compact: false,
+            minimal: false,
+            expand_symbols: vec![],
+            yes: false,
+            warn_threshold: 10_000,
+            token_budget: None,
+            with_comments: false,
         }
     }
 

--- a/src/references.rs
+++ b/src/references.rs
@@ -54,7 +54,11 @@ pub fn find_references(
     let files = if path.is_file() {
         vec![path.to_path_buf()]
     } else if path.is_dir() {
-        walk::filter_excludes(walk::walk_directory(path, options.depth, &options.ext)?, path, &options.exclude)
+        walk::filter_excludes(
+            walk::walk_directory(path, options.depth, &options.ext)?,
+            path,
+            &options.exclude,
+        )
     } else {
         return Err(CodehudError::InvalidPath(path.display().to_string()));
     };
@@ -156,7 +160,16 @@ pub fn format_plain(refs: &[Reference]) -> String {
             RefKind::Reference => " [ref]",
             RefKind::Text => " [text]",
         };
-        writeln!(out, "{}:{}:{}{} {}", r.file, r.line, r.column, kind_label, r.line_content.trim()).unwrap();
+        writeln!(
+            out,
+            "{}:{}:{}{} {}",
+            r.file,
+            r.line,
+            r.column,
+            kind_label,
+            r.line_content.trim()
+        )
+        .unwrap();
         for ctx in &r.context {
             writeln!(out, "  {}", ctx).unwrap();
         }
@@ -174,9 +187,12 @@ fn contains_word(line: &str, word: &str) -> bool {
     let mut start = 0;
     while let Some(pos) = line[start..].find(word) {
         let abs = start + pos;
-        let before_ok = abs == 0 || !line.as_bytes()[abs - 1].is_ascii_alphanumeric() && line.as_bytes()[abs - 1] != b'_';
+        let before_ok = abs == 0
+            || !line.as_bytes()[abs - 1].is_ascii_alphanumeric()
+                && line.as_bytes()[abs - 1] != b'_';
         let after = abs + word.len();
-        let after_ok = after >= line.len() || !line.as_bytes()[after].is_ascii_alphanumeric() && line.as_bytes()[after] != b'_';
+        let after_ok = after >= line.len()
+            || !line.as_bytes()[after].is_ascii_alphanumeric() && line.as_bytes()[after] != b'_';
         if before_ok && after_ok {
             return true;
         }
@@ -221,21 +237,24 @@ fn is_definition_identifier(node: Node, handler: &dyn LanguageHandler) -> bool {
     if is_definition_parent(parent.kind(), handler) {
         // Check if this node is the "name" field of the parent
         if let Some(name_node) = parent.child_by_field_name("name")
-            && name_node.id() == node.id() {
-                return true;
-            }
+            && name_node.id() == node.id()
+        {
+            return true;
+        }
         // For Rust let_declaration, the pattern field contains the name
         if parent.kind() == "let_declaration"
             && let Some(pat) = parent.child_by_field_name("pattern")
-                && pat.id() == node.id() {
-                    return true;
-                }
+            && pat.id() == node.id()
+        {
+            return true;
+        }
         // For variable_declarator (JS/TS), check name field
         if parent.kind() == "variable_declarator"
             && let Some(name_node) = parent.child_by_field_name("name")
-                && name_node.id() == node.id() {
-                    return true;
-                }
+            && name_node.id() == node.id()
+        {
+            return true;
+        }
     }
 
     false
@@ -251,9 +270,16 @@ fn is_in_string_or_comment(node: Node) -> bool {
     let mut current = node.parent();
     while let Some(n) = current {
         match n.kind() {
-            "string_literal" | "raw_string_literal" | "string" | "template_string" |
-            "string_content" | "line_comment" | "block_comment" | "comment" |
-            "string_fragment" | "concatenated_string" => return true,
+            "string_literal"
+            | "raw_string_literal"
+            | "string"
+            | "template_string"
+            | "string_content"
+            | "line_comment"
+            | "block_comment"
+            | "comment"
+            | "string_fragment"
+            | "concatenated_string" => return true,
             _ => {}
         }
         current = n.parent();
@@ -273,9 +299,17 @@ pub fn find_refs_in_tree(
     context_lines: usize,
     refs: &mut Vec<Reference>,
 ) {
-    let handler = handler::handler_for(language)
-        .expect("all supported languages have handlers");
-    find_refs_in_tree_with_handler(node, source, lines, symbol, handler.as_ref(), file_path, context_lines, refs);
+    let handler = handler::handler_for(language).expect("all supported languages have handlers");
+    find_refs_in_tree_with_handler(
+        node,
+        source,
+        lines,
+        symbol,
+        handler.as_ref(),
+        file_path,
+        context_lines,
+        refs,
+    );
 }
 
 /// Recursively find all references in a tree using a provided handler.
@@ -314,7 +348,16 @@ fn find_refs_in_tree_with_handler(
     // Recurse into children
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        find_refs_in_tree_with_handler(&child, source, lines, symbol, handler, file_path, context_lines, refs);
+        find_refs_in_tree_with_handler(
+            &child,
+            source,
+            lines,
+            symbol,
+            handler,
+            file_path,
+            context_lines,
+            refs,
+        );
     }
 }
 
@@ -336,14 +379,18 @@ mod tests {
     #[test]
     fn test_find_function_def_and_refs() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"fn hello() {
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"fn hello() {
     println!("hi");
 }
 
 fn main() {
     hello();
 }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "hello".to_string(),
             depth: None,
@@ -365,11 +412,15 @@ fn main() {
     #[test]
     fn test_excludes_string_literals() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"fn foo() {
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"fn foo() {
     let x = "foo";
     foo();
 }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "foo".to_string(),
             depth: None,
@@ -389,10 +440,14 @@ fn main() {
     #[test]
     fn test_excludes_comments() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"// call foo here
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"// call foo here
 fn foo() {}
 fn bar() { foo(); }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "foo".to_string(),
             depth: None,
@@ -412,9 +467,13 @@ fn bar() { foo(); }
     #[test]
     fn test_defs_only_filter() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"fn hello() {}
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"fn hello() {}
 fn main() { hello(); }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "hello".to_string(),
             depth: None,
@@ -433,9 +492,13 @@ fn main() { hello(); }
     #[test]
     fn test_refs_only_filter() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"fn hello() {}
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"fn hello() {}
 fn main() { hello(); }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "hello".to_string(),
             depth: None,
@@ -497,12 +560,16 @@ fn main() { hello(); }
     #[test]
     fn test_self_method_call() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"struct Foo;
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"struct Foo;
 impl Foo {
     fn bar(&self) {}
     fn baz(&self) { self.bar(); }
 }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "bar".to_string(),
             depth: None,
@@ -522,11 +589,15 @@ impl Foo {
     #[test]
     fn test_use_import_is_reference() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", r#"use std::collections::HashMap;
+        let path = write_file(
+            &dir,
+            "test.rs",
+            r#"use std::collections::HashMap;
 fn foo() {
     let m: HashMap<String, i32> = HashMap::new();
 }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "HashMap".to_string(),
             depth: None,
@@ -546,11 +617,15 @@ fn foo() {
     #[test]
     fn test_typescript_references() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.ts", r#"function greet(name: string) {
+        let path = write_file(
+            &dir,
+            "test.ts",
+            r#"function greet(name: string) {
     console.log(name);
 }
 greet("world");
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "greet".to_string(),
             depth: None,
@@ -570,11 +645,15 @@ greet("world");
     #[test]
     fn test_python_references() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.py", r#"def greet():
+        let path = write_file(
+            &dir,
+            "test.py",
+            r#"def greet():
     pass
 
 greet()
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "greet".to_string(),
             depth: None,
@@ -653,9 +732,13 @@ greet()
     #[test]
     fn test_javascript_references() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.js", r#"function hello() {}
+        let path = write_file(
+            &dir,
+            "test.js",
+            r#"function hello() {}
 hello();
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "hello".to_string(),
             depth: None,
@@ -702,13 +785,17 @@ hello();
     #[test]
     fn test_ts_class_type_annotation_ref() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.ts", r#"class Workflow {
+        let path = write_file(
+            &dir,
+            "test.ts",
+            r#"class Workflow {
     run() {}
 }
 function start(w: Workflow) {
     return w;
 }
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "Workflow".to_string(),
             depth: None,
@@ -721,18 +808,29 @@ function start(w: Workflow) {
         };
         let refs = find_references(&path, &opts).unwrap();
         // Should find: definition on line 1, type annotation on line 4
-        assert!(refs.len() >= 2, "Should find at least 2 refs, got {}", refs.len());
+        assert!(
+            refs.len() >= 2,
+            "Should find at least 2 refs, got {}",
+            refs.len()
+        );
         let type_ref = refs.iter().find(|r| r.line == 4);
-        assert!(type_ref.is_some(), "Should find Workflow in type annotation on line 4");
+        assert!(
+            type_ref.is_some(),
+            "Should find Workflow in type annotation on line 4"
+        );
         assert_eq!(type_ref.unwrap().kind, RefKind::Reference);
     }
 
     #[test]
     fn test_ts_new_expression_is_reference() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.ts", r#"class Workflow {}
+        let path = write_file(
+            &dir,
+            "test.ts",
+            r#"class Workflow {}
 const w = new Workflow();
-"#);
+"#,
+        );
         let opts = ReferenceOptions {
             symbol: "Workflow".to_string(),
             depth: None,
@@ -746,6 +844,10 @@ const w = new Workflow();
         let refs = find_references(&path, &opts).unwrap();
         assert_eq!(refs.len(), 2);
         assert_eq!(refs[0].kind, RefKind::Definition);
-        assert_eq!(refs[1].kind, RefKind::Reference, "new Workflow() should be Reference, not Definition");
+        assert_eq!(
+            refs[1].kind,
+            RefKind::Reference,
+            "new Workflow() should be Reference, not Definition"
+        );
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -36,10 +36,7 @@ pub struct SearchOptions {
 }
 
 /// Perform structural search on a path (file or directory).
-pub fn search_path(
-    path: &str,
-    options: &SearchOptions,
-) -> Result<String, CodehudError> {
+pub fn search_path(path: &str, options: &SearchOptions) -> Result<String, CodehudError> {
     let effective_pattern = if options.regex {
         // Regex mode: normalize grep/sed-style escaped alternation (`\|`) to regex alternation (`|`).
         // In POSIX BRE and many CLI tools, `\|` means alternation, but the `regex` crate
@@ -51,7 +48,11 @@ pub fn search_path(
         // then join with regex alternation.
         let parts: Vec<&str> = options.pattern.split('|').collect();
         if parts.len() > 1 {
-            parts.iter().map(|p| regex::escape(p)).collect::<Vec<_>>().join("|")
+            parts
+                .iter()
+                .map(|p| regex::escape(p))
+                .collect::<Vec<_>>()
+                .join("|")
         } else {
             regex::escape(&options.pattern)
         }
@@ -96,7 +97,11 @@ pub fn search_path(
 
     // Summary mode: show aggregate stats instead of full match context
     if options.summary {
-        return Ok(format_search_summary(&file_results, &options.pattern, options.json));
+        return Ok(format_search_summary(
+            &file_results,
+            &options.pattern,
+            options.json,
+        ));
     }
 
     // Files-first mode: list matched files with counts, then detailed results
@@ -107,8 +112,18 @@ pub fn search_path(
             let mut output = String::new();
             writeln!(output, "Files containing '{}':", options.pattern).unwrap();
             for (file_path, matches) in &file_results {
-                writeln!(output, "  {} ({} {})", file_path, matches.len(),
-                    if matches.len() == 1 { "match" } else { "matches" }).unwrap();
+                writeln!(
+                    output,
+                    "  {} ({} {})",
+                    file_path,
+                    matches.len(),
+                    if matches.len() == 1 {
+                        "match"
+                    } else {
+                        "matches"
+                    }
+                )
+                .unwrap();
             }
             output.push('\n');
             writeln!(output, "Detailed results:").unwrap();
@@ -152,15 +167,31 @@ pub fn search_path(
             }
             let total_files_all = capped_results.len() + overflow_files;
             let mut output = String::new();
-            writeln!(output, "Found '{}' in {} {} ({} total {})\n",
+            writeln!(
+                output,
+                "Found '{}' in {} {} ({} total {})\n",
                 options.pattern,
                 total_files_all,
-                if total_files_all == 1 { "file" } else { "files" },
+                if total_files_all == 1 {
+                    "file"
+                } else {
+                    "files"
+                },
                 total_matches,
-                if total_matches == 1 { "match" } else { "matches" },
-            ).unwrap();
+                if total_matches == 1 {
+                    "match"
+                } else {
+                    "matches"
+                },
+            )
+            .unwrap();
             output.push_str(&format_search_results(&capped_results, options.context));
-            writeln!(output, "\n... and {} more matches across {} files", overflow, extra_files).unwrap();
+            writeln!(
+                output,
+                "\n... and {} more matches across {} files",
+                overflow, extra_files
+            )
+            .unwrap();
             return Ok(output);
         }
     }
@@ -172,13 +203,20 @@ pub fn search_path(
         if !file_results.is_empty() {
             let total_files = file_results.len();
             let total_matches: usize = file_results.iter().map(|(_, m)| m.len()).sum();
-            writeln!(output, "Found '{}' in {} {} ({} total {})\n",
+            writeln!(
+                output,
+                "Found '{}' in {} {} ({} total {})\n",
                 options.pattern,
                 total_files,
                 if total_files == 1 { "file" } else { "files" },
                 total_matches,
-                if total_matches == 1 { "match" } else { "matches" },
-            ).unwrap();
+                if total_matches == 1 {
+                    "match"
+                } else {
+                    "matches"
+                },
+            )
+            .unwrap();
         }
         output.push_str(&format_search_results(&file_results, options.context));
         Ok(output)
@@ -187,10 +225,7 @@ pub fn search_path(
 
 /// Search a single file and return matches with structural context.
 /// Search a file, dispatching to SFC, code (with AST), or plain text search.
-fn search_any_file(
-    path: &Path,
-    regex: &Regex,
-) -> Result<Vec<SearchMatch>, CodehudError> {
+fn search_any_file(path: &Path, regex: &Regex) -> Result<Vec<SearchMatch>, CodehudError> {
     // SFC files: extract script blocks, search within each
     if let Some(sfc_kind) = crate::sfc::detect_sfc(path) {
         return search_sfc_file(path, regex, sfc_kind);
@@ -212,10 +247,7 @@ fn search_any_file(
 
 /// Search a plain text file (YAML, JSON, Markdown, .env, etc.) line by line.
 /// No AST parsing — matches have empty symbol paths.
-fn search_plain_text_file(
-    path: &Path,
-    regex: &Regex,
-) -> Result<Vec<SearchMatch>, CodehudError> {
+fn search_plain_text_file(path: &Path, regex: &Regex) -> Result<Vec<SearchMatch>, CodehudError> {
     let source = fs::read_to_string(path).map_err(|e| CodehudError::ReadError {
         path: path.display().to_string(),
         source: e,
@@ -256,7 +288,8 @@ fn search_sfc_file(
         for (idx, line) in block_lines.iter().enumerate() {
             if regex.is_match(line) {
                 let original_line = block.start_line + idx; // 1-indexed
-                let symbol_path = find_enclosing_symbols(&tree, &block.content, idx, block.language);
+                let symbol_path =
+                    find_enclosing_symbols(&tree, &block.content, idx, block.language);
                 // Use the original file line content for display
                 let display_line = if original_line > 0 && original_line <= all_lines.len() {
                     all_lines[original_line - 1].to_string()
@@ -273,10 +306,13 @@ fn search_sfc_file(
     }
 
     // Also search non-script lines (template, style) as plain text
-    let script_lines: std::collections::HashSet<usize> = blocks.iter().flat_map(|b| {
-        let end = b.start_line + b.content.lines().count();
-        b.start_line..end
-    }).collect();
+    let script_lines: std::collections::HashSet<usize> = blocks
+        .iter()
+        .flat_map(|b| {
+            let end = b.start_line + b.content.lines().count();
+            b.start_line..end
+        })
+        .collect();
 
     for (idx, line) in all_lines.iter().enumerate() {
         let line_num = idx + 1;
@@ -359,7 +395,10 @@ fn find_symbols_at_line(
             // Format impl blocks with "impl" prefix for readability
             if matches!(info.kind, crate::extractor::ItemKind::Impl) {
                 symbols.push(format!("impl {}", name));
-            } else if matches!(info.kind, crate::extractor::ItemKind::Function | crate::extractor::ItemKind::Method) {
+            } else if matches!(
+                info.kind,
+                crate::extractor::ItemKind::Function | crate::extractor::ItemKind::Method
+            ) {
                 symbols.push(format!("{}()", name));
             } else {
                 symbols.push(name);
@@ -370,7 +409,10 @@ fn find_symbols_at_line(
         // check if this is a method-like node with a name field
         let kind = node.kind();
         match kind {
-            "method_definition" | "function_item" | "function_definition" | "function_declaration" => {
+            "method_definition"
+            | "function_item"
+            | "function_definition"
+            | "function_declaration" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
                     let name = source[name_node.byte_range()].to_string();
                     symbols.push(format!("{}()", name));
@@ -430,9 +472,13 @@ fn format_search_json_files_first(file_results: &[(String, Vec<SearchMatch>)]) -
         symbol_path: Vec<String>,
     }
 
-    let file_summary: Vec<FileSummaryEntry> = file_results.iter().map(|(f, m)| {
-        FileSummaryEntry { file: f.clone(), matches: m.len() }
-    }).collect();
+    let file_summary: Vec<FileSummaryEntry> = file_results
+        .iter()
+        .map(|(f, m)| FileSummaryEntry {
+            file: f.clone(),
+            matches: m.len(),
+        })
+        .collect();
 
     let mut lines = Vec::new();
     // Emit the file_summary as the first line
@@ -457,7 +503,10 @@ fn format_search_json_files_first(file_results: &[(String, Vec<SearchMatch>)]) -
     lines.join("\n")
 }
 
-fn format_search_results(file_results: &[(String, Vec<SearchMatch>)], context: Option<usize>) -> String {
+fn format_search_results(
+    file_results: &[(String, Vec<SearchMatch>)],
+    context: Option<usize>,
+) -> String {
     let mut output = String::new();
 
     for (i, (file_path, matches)) in file_results.iter().enumerate() {
@@ -468,46 +517,53 @@ fn format_search_results(file_results: &[(String, Vec<SearchMatch>)], context: O
 
         // When context is requested, read the file lines for context display
         let file_lines: Option<Vec<String>> = context.and_then(|_| {
-            fs::read_to_string(file_path).ok().map(|s| s.lines().map(String::from).collect())
+            fs::read_to_string(file_path)
+                .ok()
+                .map(|s| s.lines().map(String::from).collect())
         });
         let ctx = context.unwrap_or(0);
 
         if ctx > 0 {
-          if let Some(ref lines) = file_lines {
-            let total_lines = lines.len();
+            if let Some(ref lines) = file_lines {
+                let total_lines = lines.len();
 
-            // Collect all match line numbers for this file
-            let match_lines: std::collections::HashSet<usize> =
-                matches.iter().map(|m| m.line_number).collect();
+                // Collect all match line numbers for this file
+                let match_lines: std::collections::HashSet<usize> =
+                    matches.iter().map(|m| m.line_number).collect();
 
-            // Build set of all lines to show (matches + context)
-            let mut lines_to_show: Vec<usize> = Vec::new();
-            for m in matches {
-                let start = if m.line_number > ctx { m.line_number - ctx } else { 1 };
-                let end = std::cmp::min(m.line_number + ctx, total_lines);
-                for ln in start..=end {
-                    lines_to_show.push(ln);
+                // Build set of all lines to show (matches + context)
+                let mut lines_to_show: Vec<usize> = Vec::new();
+                for m in matches {
+                    let start = if m.line_number > ctx {
+                        m.line_number - ctx
+                    } else {
+                        1
+                    };
+                    let end = std::cmp::min(m.line_number + ctx, total_lines);
+                    for ln in start..=end {
+                        lines_to_show.push(ln);
+                    }
                 }
-            }
-            lines_to_show.sort();
-            lines_to_show.dedup();
+                lines_to_show.sort();
+                lines_to_show.dedup();
 
-            // Print with separators between non-contiguous ranges
-            let mut prev_line: Option<usize> = None;
-            for &ln in &lines_to_show {
-                if let Some(prev) = prev_line
-                    && ln > prev + 1 {
+                // Print with separators between non-contiguous ranges
+                let mut prev_line: Option<usize> = None;
+                for &ln in &lines_to_show {
+                    if let Some(prev) = prev_line
+                        && ln > prev + 1
+                    {
                         writeln!(output, "    --").unwrap();
                     }
-                let content = lines.get(ln - 1).map(|s| s.as_str()).unwrap_or("");
-                if match_lines.contains(&ln) {
-                    writeln!(output, "    L{}:{}", ln, content).unwrap();
-                } else {
-                    writeln!(output, "    L{} {}", ln, content).unwrap();
+                    let content = lines.get(ln - 1).map(|s| s.as_str()).unwrap_or("");
+                    if match_lines.contains(&ln) {
+                        writeln!(output, "    L{}:{}", ln, content).unwrap();
+                    } else {
+                        writeln!(output, "    L{} {}", ln, content).unwrap();
+                    }
+                    prev_line = Some(ln);
                 }
-                prev_line = Some(ln);
             }
-          }
         } else {
             // Original grouped-by-symbol format
             let mut groups: BTreeMap<String, Vec<&SearchMatch>> = BTreeMap::new();
@@ -540,7 +596,11 @@ fn format_search_results(file_results: &[(String, Vec<SearchMatch>)], context: O
 }
 
 /// Format search results as an aggregate summary: totals + per-directory breakdown.
-fn format_search_summary(file_results: &[(String, Vec<SearchMatch>)], pattern: &str, json: bool) -> String {
+fn format_search_summary(
+    file_results: &[(String, Vec<SearchMatch>)],
+    pattern: &str,
+    json: bool,
+) -> String {
     if file_results.is_empty() {
         return String::new();
     }
@@ -548,7 +608,8 @@ fn format_search_summary(file_results: &[(String, Vec<SearchMatch>)], pattern: &
     let total_files = file_results.len();
 
     // Build per-directory breakdown
-    let mut dir_stats: BTreeMap<String, (usize, std::collections::BTreeSet<String>)> = BTreeMap::new();
+    let mut dir_stats: BTreeMap<String, (usize, std::collections::BTreeSet<String>)> =
+        BTreeMap::new();
     for (file_path, matches) in file_results {
         let dir = Path::new(file_path)
             .parent()
@@ -557,7 +618,9 @@ fn format_search_summary(file_results: &[(String, Vec<SearchMatch>)], pattern: &
                 if s.is_empty() { ".".to_string() } else { s }
             })
             .unwrap_or_else(|| ".".to_string());
-        let entry = dir_stats.entry(dir).or_insert_with(|| (0, std::collections::BTreeSet::new()));
+        let entry = dir_stats
+            .entry(dir)
+            .or_insert_with(|| (0, std::collections::BTreeSet::new()));
         entry.0 += matches.len();
         entry.1.insert(file_path.clone());
     }
@@ -575,10 +638,19 @@ fn format_search_summary(file_results: &[(String, Vec<SearchMatch>)], pattern: &
             matches: usize,
             files: usize,
         }
-        let dirs: Vec<DirEntry> = dir_stats.iter().map(|(dir, (match_count, file_set))| {
-            DirEntry { path: dir.clone(), matches: *match_count, files: file_set.len() }
-        }).collect();
-        let summary = SummaryJson { total_matches, total_files, directories: dirs };
+        let dirs: Vec<DirEntry> = dir_stats
+            .iter()
+            .map(|(dir, (match_count, file_set))| DirEntry {
+                path: dir.clone(),
+                matches: *match_count,
+                files: file_set.len(),
+            })
+            .collect();
+        let summary = SummaryJson {
+            total_matches,
+            total_files,
+            directories: dirs,
+        };
         return serde_json::to_string_pretty(&summary).unwrap();
     }
 
@@ -590,11 +662,22 @@ fn format_search_summary(file_results: &[(String, Vec<SearchMatch>)], pattern: &
     if !dir_stats.is_empty() {
         writeln!(output, "  Per directory:").unwrap();
         for (dir, (match_count, file_set)) in &dir_stats {
-            writeln!(output, "    {:<40} {} matches, {} files", dir, match_count, file_set.len()).unwrap();
+            writeln!(
+                output,
+                "    {:<40} {} matches, {} files",
+                dir,
+                match_count,
+                file_set.len()
+            )
+            .unwrap();
         }
     }
 
-    writeln!(output, "\nHint: use --search without --summary for full match context.").unwrap();
+    writeln!(
+        output,
+        "\nHint: use --search without --summary for full match context."
+    )
+    .unwrap();
     output
 }
 
@@ -619,14 +702,18 @@ mod tests {
     #[test]
     fn test_basic_search_rust() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn hello() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn hello() {
     println!("world");
 }
 
 fn goodbye() {
     println!("farewell");
 }
-"#);
+"#,
+        );
         let opts = SearchOptions {
             pattern: "println".to_string(),
             regex: false,
@@ -651,10 +738,14 @@ fn goodbye() {
     #[test]
     fn test_case_insensitive() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn hello() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn hello() {
     let Message = "hi";
 }
-"#);
+"#,
+        );
         // Case-sensitive: should not match "Message" with pattern "message"
         let opts = SearchOptions {
             pattern: "message".to_string(),
@@ -695,12 +786,16 @@ fn goodbye() {
     #[test]
     fn test_regex_pattern() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn process() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn process() {
     let x = 42;
     let y = 100;
     let z = "hello";
 }
-"#);
+"#,
+        );
         let opts = SearchOptions {
             pattern: r"let \w+ = \d+".to_string(),
             regex: true,
@@ -793,7 +888,10 @@ fn goodbye() {
     #[test]
     fn test_typescript_class_method() {
         let dir = TempDir::new().unwrap();
-        let path = write_ts_file(&dir, "test.ts", r#"class MyClass {
+        let path = write_ts_file(
+            &dir,
+            "test.ts",
+            r#"class MyClass {
     run() {
         this.enqueue("data");
     }
@@ -802,7 +900,8 @@ fn goodbye() {
         console.log(data);
     }
 }
-"#);
+"#,
+        );
         let opts = SearchOptions {
             pattern: "enqueue".to_string(),
             regex: false,
@@ -826,14 +925,18 @@ fn goodbye() {
     #[test]
     fn test_nested_rust_impl() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"struct Foo;
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"struct Foo;
 
 impl Foo {
     fn bar(&self) {
         self.do_thing();
     }
 }
-"#);
+"#,
+        );
         let opts = SearchOptions {
             pattern: "do_thing".to_string(),
             regex: false,
@@ -858,8 +961,16 @@ impl Foo {
         let dir = TempDir::new().unwrap();
         fs::create_dir(dir.path().join(".git")).unwrap();
         // Create files with many matches
-        write_rs_file(&dir, "a.rs", "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n");
-        write_rs_file(&dir, "b.rs", "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n");
+        write_rs_file(
+            &dir,
+            "a.rs",
+            "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n",
+        );
+        write_rs_file(
+            &dir,
+            "b.rs",
+            "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n",
+        );
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -933,13 +1044,17 @@ impl Foo {
     #[test]
     fn test_regex_or_alternation() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn check() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn check() {
     // TODO: fix this
     // FIXME: and this
     // HACK: workaround
     println!("clean line");
 }
-"#);
+"#,
+        );
         // Standard regex alternation with |
         let opts = SearchOptions {
             pattern: "TODO|FIXME|HACK".to_string(),
@@ -965,12 +1080,16 @@ impl Foo {
     #[test]
     fn test_regex_or_backslash_pipe_syntax() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn check() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn check() {
     // TODO: fix this
     // FIXME: and this
     println!("clean line");
 }
-"#);
+"#,
+        );
         // grep/sed-style \| alternation
         let opts = SearchOptions {
             pattern: r"TODO\|FIXME".to_string(),
@@ -987,19 +1106,29 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&path, &opts).unwrap();
-        assert!(result.contains("L2:"), "should match TODO line with \\| syntax");
-        assert!(result.contains("L3:"), "should match FIXME line with \\| syntax");
+        assert!(
+            result.contains("L2:"),
+            "should match TODO line with \\| syntax"
+        );
+        assert!(
+            result.contains("L3:"),
+            "should match FIXME line with \\| syntax"
+        );
         assert!(!result.contains("L4:"), "should not match clean line");
     }
 
     #[test]
     fn test_regex_or_case_insensitive() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", r#"fn check() {
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            r#"fn check() {
     // todo: lowercase
     // FIXME: uppercase
 }
-"#);
+"#,
+        );
         let opts = SearchOptions {
             pattern: "todo|fixme".to_string(),
             regex: true,
@@ -1016,7 +1145,10 @@ impl Foo {
         };
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("L2:"), "case-insensitive should match todo");
-        assert!(result.contains("L3:"), "case-insensitive should match FIXME");
+        assert!(
+            result.contains("L3:"),
+            "case-insensitive should match FIXME"
+        );
     }
 
     #[test]
@@ -1046,9 +1178,18 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&dir_str, &opts).unwrap();
-        assert!(result.contains("main.rs"), "non-test file should appear in search results");
-        assert!(!result.contains("utils.test.ts"), "--no-tests should exclude .test.ts from search");
-        assert!(!result.contains("__tests__"), "--no-tests should exclude __tests__ dir from search");
+        assert!(
+            result.contains("main.rs"),
+            "non-test file should appear in search results"
+        );
+        assert!(
+            !result.contains("utils.test.ts"),
+            "--no-tests should exclude .test.ts from search"
+        );
+        assert!(
+            !result.contains("__tests__"),
+            "--no-tests should exclude __tests__ dir from search"
+        );
     }
 
     // --- Non-code file search tests ---
@@ -1065,7 +1206,11 @@ impl Foo {
     #[test]
     fn test_search_yaml_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "config.yml", "name: my-app\nwebhook: https://example.com\nport: 8080\n");
+        let path = write_file(
+            &dir,
+            "config.yml",
+            "name: my-app\nwebhook: https://example.com\nport: 8080\n",
+        );
         let opts = SearchOptions {
             pattern: "webhook".to_string(),
             regex: false,
@@ -1091,7 +1236,11 @@ impl Foo {
     #[test]
     fn test_search_json_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "settings.json", "{\n  \"apiKey\": \"secret\",\n  \"debug\": true\n}\n");
+        let path = write_file(
+            &dir,
+            "settings.json",
+            "{\n  \"apiKey\": \"secret\",\n  \"debug\": true\n}\n",
+        );
         let opts = SearchOptions {
             pattern: "apiKey".to_string(),
             regex: false,
@@ -1114,7 +1263,11 @@ impl Foo {
     #[test]
     fn test_search_markdown_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "README.md", "# My Project\n\nThis has setupHotReload instructions.\n");
+        let path = write_file(
+            &dir,
+            "README.md",
+            "# My Project\n\nThis has setupHotReload instructions.\n",
+        );
         let opts = SearchOptions {
             pattern: "setupHotReload".to_string(),
             regex: false,
@@ -1137,7 +1290,11 @@ impl Foo {
     #[test]
     fn test_search_env_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "sample.env", "DATABASE_URL=postgres://localhost\nEXECUTIONS_MODE=queue\n");
+        let path = write_file(
+            &dir,
+            "sample.env",
+            "DATABASE_URL=postgres://localhost\nEXECUTIONS_MODE=queue\n",
+        );
         let opts = SearchOptions {
             pattern: "EXECUTIONS_MODE".to_string(),
             regex: false,
@@ -1180,8 +1337,14 @@ impl Foo {
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         assert!(result.contains("main.rs"), "should find match in code file");
-        assert!(result.contains("config.yml"), "should find match in YAML file");
-        assert!(!result.contains("README.md"), "should not include file with no matches");
+        assert!(
+            result.contains("config.yml"),
+            "should find match in YAML file"
+        );
+        assert!(
+            !result.contains("README.md"),
+            "should not include file with no matches"
+        );
     }
 
     #[test]
@@ -1206,7 +1369,10 @@ impl Foo {
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
         assert!(result.contains("config.yml"));
-        assert!(!result.contains("main.rs"), "--ext yml should exclude .rs files");
+        assert!(
+            !result.contains("main.rs"),
+            "--ext yml should exclude .rs files"
+        );
     }
 
     #[test]
@@ -1234,7 +1400,11 @@ impl Foo {
     #[test]
     fn test_summary_line_single_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", "fn hello() {\n    target();\n}\nfn bye() {\n    target();\n}\n");
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            "fn hello() {\n    target();\n}\nfn bye() {\n    target();\n}\n",
+        );
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -1303,8 +1473,16 @@ impl Foo {
     fn test_summary_line_with_max_results() {
         let dir = TempDir::new().unwrap();
         fs::create_dir(dir.path().join(".git")).unwrap();
-        write_rs_file(&dir, "a.rs", "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n");
-        write_rs_file(&dir, "b.rs", "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n");
+        write_rs_file(
+            &dir,
+            "a.rs",
+            "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n",
+        );
+        write_rs_file(
+            &dir,
+            "b.rs",
+            "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n",
+        );
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -1349,7 +1527,11 @@ impl Foo {
     #[test]
     fn test_search_toml_file() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "Cargo.toml", "[package]\nname = \"codehud\"\nversion = \"1.0.0\"\n");
+        let path = write_file(
+            &dir,
+            "Cargo.toml",
+            "[package]\nname = \"codehud\"\nversion = \"1.0.0\"\n",
+        );
         let opts = SearchOptions {
             pattern: "codehud".to_string(),
             regex: false,
@@ -1369,11 +1551,14 @@ impl Foo {
         assert!(result.contains("L2:"));
     }
 
-
     #[test]
     fn test_multi_pattern_literal_or() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", "struct TextEditor;\nstruct CodeEditor;\nstruct DiffViewer;\n");
+        let path = write_file(
+            &dir,
+            "test.rs",
+            "struct TextEditor;\nstruct CodeEditor;\nstruct DiffViewer;\n",
+        );
         let opts = SearchOptions {
             pattern: "TextEditor|CodeEditor".to_string(),
             regex: false,
@@ -1391,13 +1576,20 @@ impl Foo {
         let result = search_path(&path, &opts).unwrap();
         assert!(result.contains("TextEditor"), "should match TextEditor");
         assert!(result.contains("CodeEditor"), "should match CodeEditor");
-        assert!(!result.contains("DiffViewer"), "should not match DiffViewer");
+        assert!(
+            !result.contains("DiffViewer"),
+            "should not match DiffViewer"
+        );
     }
 
     #[test]
     fn test_multi_pattern_regex_or() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.rs", "fn foo_bar() {}\nfn baz_qux() {}\nfn hello() {}\n");
+        let path = write_file(
+            &dir,
+            "test.rs",
+            "fn foo_bar() {}\nfn baz_qux() {}\nfn hello() {}\n",
+        );
         let opts = SearchOptions {
             pattern: "foo_bar|baz_qux".to_string(),
             regex: true,
@@ -1437,14 +1629,21 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&path, &opts).unwrap();
-        assert!(result.contains("let x"), "should match single literal pattern");
+        assert!(
+            result.contains("let x"),
+            "should match single literal pattern"
+        );
         assert!(!result.contains("let y"), "should not match other lines");
     }
 
     #[test]
     fn test_context_lines_basic() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs", "fn aaa() {}\nfn bbb() {}\nfn target() {}\nfn ccc() {}\nfn ddd() {}\n");
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            "fn aaa() {}\nfn bbb() {}\nfn target() {}\nfn ccc() {}\nfn ddd() {}\n",
+        );
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -1463,15 +1662,24 @@ impl Foo {
         assert!(result.contains("L3:"), "should contain match line L3");
         assert!(result.contains("L2 "), "should contain context line L2");
         assert!(result.contains("L4 "), "should contain context line L4");
-        assert!(!result.contains("L1"), "L1 should not appear with context=1");
-        assert!(!result.contains("L5"), "L5 should not appear with context=1");
+        assert!(
+            !result.contains("L1"),
+            "L1 should not appear with context=1"
+        );
+        assert!(
+            !result.contains("L5"),
+            "L5 should not appear with context=1"
+        );
     }
 
     #[test]
     fn test_context_lines_separator_between_groups() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs",
-            "line1\nline2\ntarget_a\nline4\nline5\nline6\nline7\ntarget_b\nline9\nline10\n");
+        let path = write_rs_file(
+            &dir,
+            "test.rs",
+            "line1\nline2\ntarget_a\nline4\nline5\nline6\nline7\ntarget_b\nline9\nline10\n",
+        );
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -1487,7 +1695,10 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&path, &opts).unwrap();
-        assert!(result.contains("--"), "should contain separator between groups");
+        assert!(
+            result.contains("--"),
+            "should contain separator between groups"
+        );
         assert!(result.contains("L3:"), "match line 3");
         assert!(result.contains("L8:"), "match line 8");
     }
@@ -1495,8 +1706,7 @@ impl Foo {
     #[test]
     fn test_context_lines_overlapping_ranges() {
         let dir = TempDir::new().unwrap();
-        let path = write_rs_file(&dir, "test.rs",
-            "line1\ntarget_a\nline3\ntarget_b\nline5\n");
+        let path = write_rs_file(&dir, "test.rs", "line1\ntarget_a\nline3\ntarget_b\nline5\n");
         let opts = SearchOptions {
             pattern: "target".to_string(),
             regex: false,
@@ -1539,7 +1749,10 @@ impl Foo {
             files_first: false,
         };
         let result_none = search_path(&path, &opts_none).unwrap();
-        assert!(result_none.contains("hello()"), "should show symbol grouping without context");
+        assert!(
+            result_none.contains("hello()"),
+            "should show symbol grouping without context"
+        );
     }
 
     #[test]
@@ -1548,7 +1761,11 @@ impl Foo {
         fs::create_dir(dir.path().join(".git")).unwrap();
         fs::create_dir_all(dir.path().join("src")).unwrap();
         fs::create_dir_all(dir.path().join("lib")).unwrap();
-        write_file(&dir, "src/a.rs", "fn a() { target(); }\nfn b() { target(); }\n");
+        write_file(
+            &dir,
+            "src/a.rs",
+            "fn a() { target(); }\nfn b() { target(); }\n",
+        );
         write_file(&dir, "src/b.rs", "fn c() { target(); }\n");
         write_file(&dir, "lib/c.rs", "fn d() { target(); }\n");
         let opts = SearchOptions {
@@ -1566,12 +1783,24 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&dir.path().to_string_lossy().as_ref(), &opts).unwrap();
-        assert!(result.contains("Search summary for 'target':"), "should have summary header");
-        assert!(result.contains("Total matches: 4"), "should show total matches");
-        assert!(result.contains("Total files:   3"), "should show total files");
+        assert!(
+            result.contains("Search summary for 'target':"),
+            "should have summary header"
+        );
+        assert!(
+            result.contains("Total matches: 4"),
+            "should show total matches"
+        );
+        assert!(
+            result.contains("Total files:   3"),
+            "should show total files"
+        );
         assert!(result.contains("src"), "should show src directory");
         assert!(result.contains("lib"), "should show lib directory");
-        assert!(result.contains("Hint: use --search without --summary"), "should show hint");
+        assert!(
+            result.contains("Hint: use --search without --summary"),
+            "should show hint"
+        );
     }
 
     #[test]
@@ -1618,13 +1847,20 @@ impl Foo {
             files_first: false,
         };
         let result = search_path(&path, &opts).unwrap();
-        assert!(result.is_empty(), "summary with no matches should be empty (caught by caller)");
+        assert!(
+            result.is_empty(),
+            "summary with no matches should be empty (caught by caller)"
+        );
     }
 
     #[test]
     fn test_files_first_plain() {
         let dir = TempDir::new().unwrap();
-        write_rs_file(&dir, "a.rs", "fn foo() { hello(); }\nfn bar() { hello(); hello(); }\n");
+        write_rs_file(
+            &dir,
+            "a.rs",
+            "fn foo() { hello(); }\nfn bar() { hello(); hello(); }\n",
+        );
         write_rs_file(&dir, "b.rs", "fn baz() { hello(); }\n");
         let path = dir.path().to_string_lossy().to_string();
         let opts = SearchOptions {

--- a/src/sfc.rs
+++ b/src/sfc.rs
@@ -47,25 +47,23 @@ pub fn is_sfc_file(path: &Path) -> bool {
 }
 
 // Regex for matching <script> opening tags with optional attributes
-static SCRIPT_OPEN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)<script\b([^>]*)>"#).unwrap()
-});
+static SCRIPT_OPEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)<script\b([^>]*)>"#).unwrap());
 
 // Regex for matching </script> closing tags
-static SCRIPT_CLOSE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)</script\s*>"#).unwrap()
-});
+static SCRIPT_CLOSE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)</script\s*>"#).unwrap());
 
 // Regex for Astro frontmatter delimiters
-static ASTRO_FENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"^---\s*$"#).unwrap()
-});
+static ASTRO_FENCE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^---\s*$"#).unwrap());
 
 /// Detect language from script tag attributes (e.g., `lang="ts"`).
 fn detect_script_lang(attrs: &str) -> Language {
     let lower = attrs.to_lowercase();
-    if lower.contains("lang=\"ts\"") || lower.contains("lang='ts'")
-        || lower.contains("lang=\"typescript\"") || lower.contains("lang='typescript'")
+    if lower.contains("lang=\"ts\"")
+        || lower.contains("lang='ts'")
+        || lower.contains("lang=\"typescript\"")
+        || lower.contains("lang='typescript'")
     {
         Language::TypeScript
     } else if lower.contains("lang=\"tsx\"") || lower.contains("lang='tsx'") {
@@ -300,7 +298,10 @@ const title = "Hello";
     #[test]
     fn detect_sfc_extensions() {
         assert_eq!(detect_sfc(Path::new("App.vue")), Some(SfcKind::Vue));
-        assert_eq!(detect_sfc(Path::new("Counter.svelte")), Some(SfcKind::Svelte));
+        assert_eq!(
+            detect_sfc(Path::new("Counter.svelte")),
+            Some(SfcKind::Svelte)
+        );
         assert_eq!(detect_sfc(Path::new("index.astro")), Some(SfcKind::Astro));
         assert_eq!(detect_sfc(Path::new("main.ts")), None);
     }

--- a/src/skill/claude_code.rs
+++ b/src/skill/claude_code.rs
@@ -98,10 +98,10 @@ fn install_slash_command() -> Result<(), CodehudError> {
 
 fn uninstall_slash_command() {
     let path = PathBuf::from(".claude/commands/codehud.md");
-    if path.exists() {
-        if let Ok(()) = fs::remove_file(&path) {
-            println!("Removed {}", path.display());
-        }
+    if path.exists()
+        && let Ok(()) = fs::remove_file(&path)
+    {
+        println!("Removed {}", path.display());
     }
 }
 

--- a/src/skill/codex.rs
+++ b/src/skill/codex.rs
@@ -124,8 +124,10 @@ mod tests {
 
     #[test]
     fn remove_block_strips_delimited_section() {
-        let content = format!("# My File\n\n{}\nsome content\n{}\n\n# End\n",
-            START_DELIMITER, END_DELIMITER);
+        let content = format!(
+            "# My File\n\n{}\nsome content\n{}\n\n# End\n",
+            START_DELIMITER, END_DELIMITER
+        );
         let result = remove_block(&content);
         assert!(!result.contains(START_DELIMITER));
         assert!(!result.contains(END_DELIMITER));

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -1,10 +1,10 @@
-pub mod content;
-mod openclaw;
-mod opencode;
+mod aider;
 mod claude_code;
 mod codex;
+pub mod content;
 mod cursor;
-mod aider;
+mod openclaw;
+mod opencode;
 
 use crate::CodehudError;
 
@@ -19,7 +19,14 @@ pub trait PlatformAdapter {
 }
 
 /// All supported platform names.
-pub const PLATFORMS: &[&str] = &["openclaw", "opencode", "claude-code", "codex", "cursor", "aider"];
+pub const PLATFORMS: &[&str] = &[
+    "openclaw",
+    "opencode",
+    "claude-code",
+    "codex",
+    "cursor",
+    "aider",
+];
 
 /// List all available platforms to stdout.
 pub fn list_platforms() {

--- a/src/skill/opencode.rs
+++ b/src/skill/opencode.rs
@@ -1,5 +1,5 @@
-use super::content::SKILL_CONTENT;
 use super::PlatformAdapter;
+use super::content::SKILL_CONTENT;
 use crate::CodehudError;
 use std::fs;
 use std::path::PathBuf;

--- a/src/test_detect.rs
+++ b/src/test_detect.rs
@@ -37,9 +37,10 @@ impl TestDetector for RustTestDetector {
             return true;
         }
         if matches!(item.kind, ItemKind::Function | ItemKind::Method)
-            && (item.content.contains("#[test]") || item.content.contains("#[tokio::test]")) {
-                return true;
-            }
+            && (item.content.contains("#[test]") || item.content.contains("#[tokio::test]"))
+        {
+            return true;
+        }
         false
     }
 }
@@ -61,9 +62,7 @@ impl TestDetector for CppTestDetector {
     fn is_test_file(&self, path: &Path) -> bool {
         let path_str = path.to_string_lossy();
         let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-        has_test_dir_component(&path_str)
-            || stem.ends_with("_test")
-            || stem.starts_with("test_")
+        has_test_dir_component(&path_str) || stem.ends_with("_test") || stem.starts_with("test_")
     }
     fn is_test_item(&self, _item: &Item) -> bool {
         false
@@ -114,14 +113,16 @@ impl TestDetector for PythonTestDetector {
     fn is_test_item(&self, item: &Item) -> bool {
         if matches!(item.kind, ItemKind::Function | ItemKind::Method)
             && let Some(ref name) = item.name
-                && name.starts_with("test_") {
-                    return true;
-                }
+            && name.starts_with("test_")
+        {
+            return true;
+        }
         if matches!(item.kind, ItemKind::Class)
             && let Some(ref name) = item.name
-                && name.starts_with("Test") {
-                    return true;
-                }
+            && name.starts_with("Test")
+        {
+            return true;
+        }
         false
     }
 }
@@ -141,14 +142,16 @@ impl TestDetector for JavaTestDetector {
         // Java test methods are typically annotated with @Test — detected via name heuristics here
         if matches!(item.kind, ItemKind::Function | ItemKind::Method)
             && let Some(ref name) = item.name
-                && (name.starts_with("test") || name.starts_with("should")) {
-                    return true;
-                }
+            && (name.starts_with("test") || name.starts_with("should"))
+        {
+            return true;
+        }
         if matches!(item.kind, ItemKind::Class)
             && let Some(ref name) = item.name
-                && (name.ends_with("Test") || name.ends_with("Tests")) {
-                    return true;
-                }
+            && (name.ends_with("Test") || name.ends_with("Tests"))
+        {
+            return true;
+        }
         false
     }
 }
@@ -191,11 +194,16 @@ pub fn is_js_ts_test_filename(stem: &str, _file_name: &str) -> bool {
 /// Check if an item looks like a JS/TS test block: describe(), it(), test()
 pub fn is_js_test_call(item: &Item) -> bool {
     if matches!(item.kind, ItemKind::Function)
-        && let Some(ref name) = item.name {
-            let n = name.as_str();
-            return n == "describe" || n == "it" || n == "test"
-                || n.starts_with("describe(") || n.starts_with("it(") || n.starts_with("test(");
-        }
+        && let Some(ref name) = item.name
+    {
+        let n = name.as_str();
+        return n == "describe"
+            || n == "it"
+            || n == "test"
+            || n.starts_with("describe(")
+            || n.starts_with("it(")
+            || n.starts_with("test(");
+    }
     false
 }
 
@@ -207,9 +215,12 @@ impl TestDetector for GoTestDetector {
     }
     fn is_test_item(&self, item: &Item) -> bool {
         if matches!(item.kind, ItemKind::Function)
-            && let Some(ref name) = item.name {
-                return name.starts_with("Test") || name.starts_with("Benchmark") || name.starts_with("Example");
-            }
+            && let Some(ref name) = item.name
+        {
+            return name.starts_with("Test")
+                || name.starts_with("Benchmark")
+                || name.starts_with("Example");
+        }
         false
     }
 }
@@ -230,6 +241,7 @@ mod tests {
             content: content.to_string(),
             signature: None,
             body: None,
+            doc_comment: None,
             line_mappings: None,
         }
     }
@@ -299,7 +311,11 @@ mod tests {
     #[test]
     fn ts_describe_block() {
         let d = detector_for(Language::TypeScript);
-        let item = make_item(ItemKind::Function, "describe", "describe('suite', () => {})");
+        let item = make_item(
+            ItemKind::Function,
+            "describe",
+            "describe('suite', () => {})",
+        );
         assert!(d.is_test_item(&item));
     }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -49,7 +49,10 @@ fn truncate_plain_to_budget(output: &str, budget: usize) -> String {
     while lo < hi {
         let mid = (lo + hi).div_ceil(2);
         let candidate: String = lines[..mid].join("\n");
-        let footer = format!("\n[Truncated: showed {}/{} items to stay within {} token budget]\n", mid, total, budget);
+        let footer = format!(
+            "\n[Truncated: showed {}/{} items to stay within {} token budget]\n",
+            mid, total, budget
+        );
         if estimate_tokens(&format!("{}{}", candidate, footer)) <= budget {
             lo = mid;
         } else {
@@ -58,7 +61,10 @@ fn truncate_plain_to_budget(output: &str, budget: usize) -> String {
     }
     let shown = lo;
     let mut result: String = lines[..shown].join("\n");
-    result.push_str(&format!("\n[Truncated: showed {}/{} items to stay within {} token budget]\n", shown, total, budget));
+    result.push_str(&format!(
+        "\n[Truncated: showed {}/{} items to stay within {} token budget]\n",
+        shown, total, budget
+    ));
     result
 }
 
@@ -75,7 +81,10 @@ fn truncate_json_to_budget(output: &str, budget: usize) -> String {
                 let mid = (lo + hi).div_ceil(2);
                 let slice = &items[..mid];
                 let candidate = serde_json::to_string(slice).unwrap_or_default();
-                let footer = format!("\n[Truncated: showed {}/{} items to stay within {} token budget]\n", mid, total, budget);
+                let footer = format!(
+                    "\n[Truncated: showed {}/{} items to stay within {} token budget]\n",
+                    mid, total, budget
+                );
                 if estimate_tokens(&format!("{}{}", candidate, footer)) <= budget {
                     lo = mid;
                 } else {
@@ -83,8 +92,12 @@ fn truncate_json_to_budget(output: &str, budget: usize) -> String {
                 }
             }
             let shown = lo;
-            let mut result = serde_json::to_string(&items[..shown]).unwrap_or_else(|_| "[]".to_string());
-            result.push_str(&format!("\n[Truncated: showed {}/{} items to stay within {} token budget]\n", shown, total, budget));
+            let mut result =
+                serde_json::to_string(&items[..shown]).unwrap_or_else(|_| "[]".to_string());
+            result.push_str(&format!(
+                "\n[Truncated: showed {}/{} items to stay within {} token budget]\n",
+                shown, total, budget
+            ));
             result
         }
         Err(_) => {
@@ -171,7 +184,10 @@ mod tests {
         assert!(result.contains("token budget]"));
         assert!(estimate_tokens(&result) <= budget);
         // Should have fewer than 10 lines
-        let content_lines = result.lines().filter(|l| !l.starts_with("[Truncated:")).count();
+        let content_lines = result
+            .lines()
+            .filter(|l| !l.starts_with("[Truncated:"))
+            .count();
         assert!(content_lines < 10);
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -34,13 +34,19 @@ pub fn list_files(dir: &str, opts: &TreeOptions) -> Result<String, CodehudError>
         return Err(CodehudError::PathNotFound(dir.to_string()));
     }
     if !path.is_dir() {
-        return Err(CodehudError::InvalidPath(format!("{} is not a directory", dir)));
+        return Err(CodehudError::InvalidPath(format!(
+            "{} is not a directory",
+            dir
+        )));
     }
 
     let files = walk::walk_directory_smart(path, opts.depth, &opts.ext, opts.smart_depth)?;
     let files = walk::filter_excludes(files, path, &opts.exclude);
     let files = if opts.no_tests {
-        files.into_iter().filter(|f| !crate::test_detect::is_test_file_any_language(f)).collect()
+        files
+            .into_iter()
+            .filter(|f| !crate::test_detect::is_test_file_any_language(f))
+            .collect()
     } else {
         files
     };
@@ -73,13 +79,19 @@ pub fn tree_view(dir: &str, opts: &TreeOptions) -> Result<String, CodehudError> 
         return Err(CodehudError::PathNotFound(dir.to_string()));
     }
     if !path.is_dir() {
-        return Err(CodehudError::InvalidPath(format!("{} is not a directory", dir)));
+        return Err(CodehudError::InvalidPath(format!(
+            "{} is not a directory",
+            dir
+        )));
     }
 
     let files = walk::walk_directory_smart(path, opts.depth, &opts.ext, opts.smart_depth)?;
     let files = walk::filter_excludes(files, path, &opts.exclude);
     let files = if opts.no_tests {
-        files.into_iter().filter(|f| !crate::test_detect::is_test_file_any_language(f)).collect()
+        files
+            .into_iter()
+            .filter(|f| !crate::test_detect::is_test_file_any_language(f))
+            .collect()
     } else {
         files
     };
@@ -91,9 +103,7 @@ pub fn tree_view(dir: &str, opts: &TreeOptions) -> Result<String, CodehudError> 
 
     // Build a tree structure from flat file list
     let tree = build_tree(&files, path);
-    let dir_name = path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(".");
+    let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or(".");
 
     let mut out = String::new();
     writeln!(out, "{}/", dir_name).unwrap();
@@ -106,12 +116,19 @@ pub fn tree_view(dir: &str, opts: &TreeOptions) -> Result<String, CodehudError> 
     Ok(out)
 }
 
-fn build_entries(files: &[PathBuf], base: &Path, with_stats: bool) -> Result<Vec<FileEntry>, CodehudError> {
+fn build_entries(
+    files: &[PathBuf],
+    base: &Path,
+    with_stats: bool,
+) -> Result<Vec<FileEntry>, CodehudError> {
     let mut entries = Vec::with_capacity(files.len());
     for file in files {
         let rel = file.strip_prefix(base).unwrap_or(file);
         let size = fs::metadata(file).map(|m| m.len()).unwrap_or(0);
-        let ext = file.extension().and_then(|e| e.to_str()).map(|s| s.to_string());
+        let ext = file
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_string());
         let is_supported = languages::is_supported_file(file);
 
         let symbols = if with_stats && is_supported {
@@ -168,7 +185,11 @@ fn build_tree(files: &[PathBuf], base: &Path) -> BTreeMap<String, TreeNode> {
     root
 }
 
-fn insert_into_tree(node: &mut BTreeMap<String, TreeNode>, components: &[&str], full_path: PathBuf) {
+fn insert_into_tree(
+    node: &mut BTreeMap<String, TreeNode>,
+    components: &[&str],
+    full_path: PathBuf,
+) {
     if components.is_empty() {
         return;
     }
@@ -176,7 +197,9 @@ fn insert_into_tree(node: &mut BTreeMap<String, TreeNode>, components: &[&str], 
         node.insert(components[0].to_string(), TreeNode::File(full_path));
     } else {
         let dir_name = components[0].to_string();
-        let child = node.entry(dir_name).or_insert_with(|| TreeNode::Dir(BTreeMap::new()));
+        let child = node
+            .entry(dir_name)
+            .or_insert_with(|| TreeNode::Dir(BTreeMap::new()));
         if let TreeNode::Dir(children) = child {
             insert_into_tree(children, &components[1..], full_path);
         }
@@ -214,7 +237,12 @@ fn render_tree(
                     let is_supported = languages::is_supported_file(path);
                     if is_supported {
                         let syms = count_symbols(path);
-                        writeln!(out, "{}{}{}  ({}, {} syms)", prefix, connector, name, size_str, syms).unwrap();
+                        writeln!(
+                            out,
+                            "{}{}{}  ({}, {} syms)",
+                            prefix, connector, name, size_str, syms
+                        )
+                        .unwrap();
                     } else {
                         writeln!(out, "{}{}{}  ({})", prefix, connector, name, size_str).unwrap();
                     }
@@ -264,18 +292,33 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::create_dir(dir.path().join(".git")).unwrap();
         fs::create_dir(dir.path().join("src")).unwrap();
-        fs::write(dir.path().join("src/main.rs"), "fn main() {}\nfn helper() {}\n").unwrap();
+        fs::write(
+            dir.path().join("src/main.rs"),
+            "fn main() {}\nfn helper() {}\n",
+        )
+        .unwrap();
         fs::write(dir.path().join("src/lib.rs"), "pub fn foo() {}\n").unwrap();
         fs::write(dir.path().join("README.md"), "# Hello\n").unwrap();
-        fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"test\"\n").unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"test\"\n",
+        )
+        .unwrap();
         dir
     }
 
     #[test]
     fn test_files_flat_listing() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(output.contains("src/main.rs"));
         assert!(output.contains("src/lib.rs"));
@@ -289,8 +332,15 @@ mod tests {
     #[test]
     fn test_files_ext_filter() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(output.contains("main.rs"));
         assert!(!output.contains("README.md"));
@@ -300,8 +350,15 @@ mod tests {
     #[test]
     fn test_files_depth_filter() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: Some(0), ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: Some(0),
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(!output.contains("src/main.rs"));
         assert!(output.contains("README.md"));
@@ -310,8 +367,15 @@ mod tests {
     #[test]
     fn test_files_json_output() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: false, json: true, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: false,
+            json: true,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         let entries: Vec<FileEntry> = serde_json::from_str(&output).unwrap();
         assert!(entries.len() >= 2);
@@ -322,8 +386,15 @@ mod tests {
     #[test]
     fn test_files_stats() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: true, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: true,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(output.contains("syms"));
         assert!(output.contains("src/main.rs"));
@@ -332,8 +403,15 @@ mod tests {
     #[test]
     fn test_files_stats_json() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: true, json: true, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: true,
+            json: true,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = list_files(dir.path().to_str().unwrap(), &opts).unwrap();
         let entries: Vec<FileEntry> = serde_json::from_str(&output).unwrap();
         // With stats, supported files should have symbol counts
@@ -345,8 +423,15 @@ mod tests {
     #[test]
     fn test_tree_view() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = tree_view(dir.path().to_str().unwrap(), &opts).unwrap();
         // Should have tree drawing characters
         assert!(output.contains("├── ") || output.contains("└── "));
@@ -359,8 +444,15 @@ mod tests {
     #[test]
     fn test_tree_with_ext_filter() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = tree_view(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(output.contains("main.rs"));
         assert!(!output.contains("README.md"));
@@ -369,8 +461,15 @@ mod tests {
     #[test]
     fn test_tree_with_stats() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: true, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: true,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = tree_view(dir.path().to_str().unwrap(), &opts).unwrap();
         assert!(output.contains("syms"));
     }
@@ -378,8 +477,15 @@ mod tests {
     #[test]
     fn test_tree_json_output() {
         let dir = setup_test_dir();
-        let opts = TreeOptions { depth: None, ext: vec!["rs".to_string()], stats: false, json: true, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec!["rs".to_string()],
+            stats: false,
+            json: true,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let output = tree_view(dir.path().to_str().unwrap(), &opts).unwrap();
         let entries: Vec<FileEntry> = serde_json::from_str(&output).unwrap();
         assert!(!entries.is_empty());
@@ -387,8 +493,15 @@ mod tests {
 
     #[test]
     fn test_files_nonexistent_dir() {
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let result = list_files("/nonexistent_xyz", &opts);
         assert!(result.is_err());
     }
@@ -397,7 +510,11 @@ mod tests {
     fn test_files_smart_depth_pnpm_monorepo() {
         let dir = tempfile::TempDir::new().unwrap();
         // Simulate pnpm monorepo
-        fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - 'packages/*'").unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'",
+        )
+        .unwrap();
         fs::write(dir.path().join("package.json"), r#"{"name": "root"}"#).unwrap();
         fs::create_dir_all(dir.path().join("packages/ui/src")).unwrap();
         fs::write(dir.path().join("packages/ui/src/Button.tsx"), "export {}").unwrap();
@@ -407,32 +524,69 @@ mod tests {
         let dir_str = dir.path().to_str().unwrap();
 
         // Without smart_depth at depth 0, we should NOT see deep files
-        let opts_no_smart = TreeOptions { depth: Some(0), ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts_no_smart = TreeOptions {
+            depth: Some(0),
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let result = list_files(dir_str, &opts_no_smart).unwrap();
-        assert!(!result.contains("Button.tsx"), "depth 0 without smart-depth should not find Button.tsx");
+        assert!(
+            !result.contains("Button.tsx"),
+            "depth 0 without smart-depth should not find Button.tsx"
+        );
 
         // With smart_depth at depth 0, we SHOULD see files inside source roots
-        let opts_smart = TreeOptions { depth: Some(0), ext: vec![], stats: false, json: false, smart_depth: true, no_tests: false,
-        exclude: vec![], };
+        let opts_smart = TreeOptions {
+            depth: Some(0),
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: true,
+            no_tests: false,
+            exclude: vec![],
+        };
         let result = list_files(dir_str, &opts_smart).unwrap();
-        assert!(result.contains("Button.tsx"), "smart-depth should find Button.tsx in packages/ui/src/");
-        assert!(result.contains("index.ts"), "smart-depth should find index.ts in packages/core/src/");
+        assert!(
+            result.contains("Button.tsx"),
+            "smart-depth should find Button.tsx in packages/ui/src/"
+        );
+        assert!(
+            result.contains("index.ts"),
+            "smart-depth should find index.ts in packages/core/src/"
+        );
     }
 
     #[test]
     fn test_tree_smart_depth_pnpm_monorepo() {
         let dir = tempfile::TempDir::new().unwrap();
-        fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - 'packages/*'").unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'",
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("packages/ui/src")).unwrap();
         fs::write(dir.path().join("packages/ui/src/Button.tsx"), "export {}").unwrap();
 
         let dir_str = dir.path().to_str().unwrap();
 
-        let opts_smart = TreeOptions { depth: Some(0), ext: vec![], stats: false, json: false, smart_depth: true, no_tests: false,
-        exclude: vec![], };
+        let opts_smart = TreeOptions {
+            depth: Some(0),
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: true,
+            no_tests: false,
+            exclude: vec![],
+        };
         let result = tree_view(dir_str, &opts_smart).unwrap();
-        assert!(result.contains("Button.tsx"), "tree smart-depth should find Button.tsx");
+        assert!(
+            result.contains("Button.tsx"),
+            "tree smart-depth should find Button.tsx"
+        );
     }
 
     #[test]
@@ -449,20 +603,40 @@ mod tests {
         let dir_str = dir.path().to_str().unwrap();
 
         // Without no_tests: all files present
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: false,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: false,
+            exclude: vec![],
+        };
         let result = list_files(dir_str, &opts).unwrap();
         assert!(result.contains("utils.test.ts"));
         assert!(result.contains("__tests__/foo.ts"));
 
         // With no_tests: test files excluded
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: true,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: true,
+            exclude: vec![],
+        };
         let result = list_files(dir_str, &opts).unwrap();
         assert!(result.contains("index.ts"));
         assert!(result.contains("src/utils.ts"));
-        assert!(!result.contains("utils.test.ts"), "--no-tests should exclude .test.ts files");
-        assert!(!result.contains("__tests__"), "--no-tests should exclude __tests__ directory files");
+        assert!(
+            !result.contains("utils.test.ts"),
+            "--no-tests should exclude .test.ts files"
+        );
+        assert!(
+            !result.contains("__tests__"),
+            "--no-tests should exclude __tests__ directory files"
+        );
     }
 
     #[test]
@@ -476,11 +650,24 @@ mod tests {
 
         let dir_str = dir.path().to_str().unwrap();
 
-        let opts = TreeOptions { depth: None, ext: vec![], stats: false, json: false, smart_depth: false, no_tests: true,
-        exclude: vec![], };
+        let opts = TreeOptions {
+            depth: None,
+            ext: vec![],
+            stats: false,
+            json: false,
+            smart_depth: false,
+            no_tests: true,
+            exclude: vec![],
+        };
         let result = tree_view(dir_str, &opts).unwrap();
         assert!(result.contains("index.ts"));
-        assert!(!result.contains("index.test.ts"), "--no-tests should exclude .test.ts in tree view");
-        assert!(!result.contains("__tests__"), "--no-tests should exclude __tests__ dir in tree view");
+        assert!(
+            !result.contains("index.test.ts"),
+            "--no-tests should exclude .test.ts in tree view"
+        );
+        assert!(
+            !result.contains("__tests__"),
+            "--no-tests should exclude __tests__ dir in tree view"
+        );
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -31,7 +31,8 @@ pub fn warn_if_costly(file_count: usize, skip_warning: bool, threshold: usize) {
     if skip_warning || !std::io::stderr().is_terminal() {
         return;
     }
-    let estimated_tokens = crate::tokens::estimate_from_file_count(file_count, DEFAULT_AVG_BYTES_PER_FILE);
+    let estimated_tokens =
+        crate::tokens::estimate_from_file_count(file_count, DEFAULT_AVG_BYTES_PER_FILE);
     if estimated_tokens >= threshold {
         let k = estimated_tokens / 1000;
         let cost = crate::tokens::estimate_cost(estimated_tokens, false);
@@ -56,7 +57,8 @@ pub fn filter_excludes(files: Vec<PathBuf>, base: &Path, exclude: &[String]) -> 
     for pattern in exclude {
         // If pattern has no glob chars or path separators, wrap as **/{pattern}/**
         // to match as a directory component, plus **/{pattern} for leaf matches
-        let patterns = if !pattern.contains('*') && !pattern.contains('/') && !pattern.contains('?') {
+        let patterns = if !pattern.contains('*') && !pattern.contains('/') && !pattern.contains('?')
+        {
             vec![format!("**/{pattern}"), format!("**/{pattern}/**")]
         } else {
             vec![pattern.clone()]
@@ -96,31 +98,53 @@ pub fn detect_monorepo_source_roots(root: &Path) -> Vec<PathBuf> {
     let pkg_json = root.join("package.json");
     if pkg_json.is_file()
         && let Ok(content) = std::fs::read_to_string(&pkg_json)
-            && content.contains("\"workspaces\"") {
-                collect_glob_source_roots(root, &["packages", "apps", "libs", "modules", "services"], &mut source_roots);
-            }
+        && content.contains("\"workspaces\"")
+    {
+        collect_glob_source_roots(
+            root,
+            &["packages", "apps", "libs", "modules", "services"],
+            &mut source_roots,
+        );
+    }
 
     // Check pnpm-workspace.yaml
     if root.join("pnpm-workspace.yaml").is_file() || root.join("pnpm-workspace.yml").is_file() {
-        collect_glob_source_roots(root, &["packages", "apps", "libs", "modules", "services"], &mut source_roots);
+        collect_glob_source_roots(
+            root,
+            &["packages", "apps", "libs", "modules", "services"],
+            &mut source_roots,
+        );
     }
 
     // Check Cargo.toml workspace
     let cargo_toml = root.join("Cargo.toml");
     if cargo_toml.is_file()
         && let Ok(content) = std::fs::read_to_string(&cargo_toml)
-            && content.contains("[workspace]") {
-                collect_glob_source_roots(root, &["crates", "packages", "libs", "modules"], &mut source_roots);
-            }
+        && content.contains("[workspace]")
+    {
+        collect_glob_source_roots(
+            root,
+            &["crates", "packages", "libs", "modules"],
+            &mut source_roots,
+        );
+    }
 
     // Check go.work
     if root.join("go.work").is_file() {
-        collect_glob_source_roots(root, &["cmd", "internal", "pkg", "services"], &mut source_roots);
+        collect_glob_source_roots(
+            root,
+            &["cmd", "internal", "pkg", "services"],
+            &mut source_roots,
+        );
     }
 
     // Check lerna.json
     if root.join("lerna.json").is_file() {
-        collect_glob_source_roots(root, &["packages", "apps", "libs", "modules"], &mut source_roots);
+        collect_glob_source_roots(
+            root,
+            &["packages", "apps", "libs", "modules"],
+            &mut source_roots,
+        );
     }
 
     source_roots
@@ -205,16 +229,29 @@ pub fn walk_directory_smart(
 
 /// Walk a directory and collect all supported source files.
 /// Respects .gitignore, .ignore, and global gitignore rules.
-pub fn walk_directory(path: &Path, max_depth: Option<usize>, ext_filter: &[String]) -> Result<Vec<PathBuf>, CodehudError> {
+pub fn walk_directory(
+    path: &Path,
+    max_depth: Option<usize>,
+    ext_filter: &[String],
+) -> Result<Vec<PathBuf>, CodehudError> {
     walk_directory_inner(path, max_depth, ext_filter, true)
 }
 
 /// Walk a directory using parallel traversal (unsorted). Much faster for large repos.
-pub fn walk_directory_parallel(path: &Path, max_depth: Option<usize>, ext_filter: &[String]) -> Result<Vec<PathBuf>, CodehudError> {
+pub fn walk_directory_parallel(
+    path: &Path,
+    max_depth: Option<usize>,
+    ext_filter: &[String],
+) -> Result<Vec<PathBuf>, CodehudError> {
     walk_directory_inner(path, max_depth, ext_filter, false)
 }
 
-fn walk_directory_inner(path: &Path, max_depth: Option<usize>, ext_filter: &[String], sorted: bool) -> Result<Vec<PathBuf>, CodehudError> {
+fn walk_directory_inner(
+    path: &Path,
+    max_depth: Option<usize>,
+    ext_filter: &[String],
+    sorted: bool,
+) -> Result<Vec<PathBuf>, CodehudError> {
     // Verify path exists and is readable before walking
     if !path.is_dir() {
         return Err(CodehudError::ReadError {
@@ -225,10 +262,10 @@ fn walk_directory_inner(path: &Path, max_depth: Option<usize>, ext_filter: &[Str
 
     let mut builder = WalkBuilder::new(path);
     builder
-        .hidden(true)          // skip hidden files/dirs
-        .git_ignore(true)      // respect .gitignore
-        .git_global(true)      // respect global gitignore
-        .git_exclude(true);    // respect .git/info/exclude
+        .hidden(true) // skip hidden files/dirs
+        .git_ignore(true) // respect .gitignore
+        .git_global(true) // respect global gitignore
+        .git_exclude(true); // respect .git/info/exclude
 
     if sorted {
         builder.sort_by_file_path(|a, b| a.cmp(b));
@@ -299,7 +336,6 @@ fn walk_directory_inner(path: &Path, max_depth: Option<usize>, ext_filter: &[Str
 
     Ok(files)
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -459,7 +495,11 @@ mod tests {
     fn smart_depth_detects_node_monorepo() {
         let dir = TempDir::new().unwrap();
         // Root config
-        fs::write(dir.path().join("package.json"), r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces": ["packages/*"]}"#,
+        )
+        .unwrap();
         fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
         // Deep source file
         fs::create_dir_all(dir.path().join("packages/core/src")).unwrap();
@@ -467,24 +507,44 @@ mod tests {
 
         // Without smart depth, depth 0 only finds root files
         let normal = walk_directory(dir.path(), Some(0), &[]).unwrap();
-        assert!(!normal.iter().any(|f| f.to_string_lossy().contains("index.ts")));
+        assert!(
+            !normal
+                .iter()
+                .any(|f| f.to_string_lossy().contains("index.ts"))
+        );
 
         // With smart depth, depth 1 finds root files AND source files in detected roots
         let smart = walk_directory_smart(dir.path(), Some(1), &[], true).unwrap();
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("index.ts")));
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("package.json")));
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("index.ts"))
+        );
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("package.json"))
+        );
     }
 
     #[test]
     fn smart_depth_detects_rust_workspace() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("Cargo.toml"), "[workspace]\nmembers = [\"crates/*\"]").unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]",
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("crates/core/src")).unwrap();
         fs::write(dir.path().join("crates/core/src/lib.rs"), "").unwrap();
 
         let smart = walk_directory_smart(dir.path(), Some(1), &[], true).unwrap();
         assert!(smart.iter().any(|f| f.to_string_lossy().contains("lib.rs")));
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("Cargo.toml")));
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("Cargo.toml"))
+        );
     }
 
     #[test]
@@ -503,7 +563,11 @@ mod tests {
     #[test]
     fn smart_depth_no_duplicates() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("package.json"), r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces": ["packages/*"]}"#,
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("packages/foo/src")).unwrap();
         fs::write(dir.path().join("packages/foo/src/lib.rs"), "").unwrap();
 
@@ -517,25 +581,45 @@ mod tests {
     #[test]
     fn smart_depth_with_ext_filter() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("package.json"), r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces": ["packages/*"]}"#,
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("packages/core/src")).unwrap();
         fs::write(dir.path().join("packages/core/src/index.ts"), "export {}").unwrap();
         fs::write(dir.path().join("packages/core/src/style.css"), "body {}").unwrap();
 
         let smart = walk_directory_smart(dir.path(), Some(1), &["ts".to_string()], true).unwrap();
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("index.ts")));
-        assert!(!smart.iter().any(|f| f.to_string_lossy().contains("style.css")));
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("index.ts"))
+        );
+        assert!(
+            !smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("style.css"))
+        );
     }
 
     #[test]
     fn smart_depth_pnpm_workspace() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - 'packages/*'").unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'",
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("packages/ui/src")).unwrap();
         fs::write(dir.path().join("packages/ui/src/Button.tsx"), "export {}").unwrap();
 
         let smart = walk_directory_smart(dir.path(), Some(1), &[], true).unwrap();
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("Button.tsx")));
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("Button.tsx"))
+        );
     }
 
     #[test]
@@ -547,13 +631,21 @@ mod tests {
 
         // go.work triggers detection; cmd/ children don't have src/ so they're source roots themselves
         let smart = walk_directory_smart(dir.path(), Some(1), &[], true).unwrap();
-        assert!(smart.iter().any(|f| f.to_string_lossy().contains("main.go")));
+        assert!(
+            smart
+                .iter()
+                .any(|f| f.to_string_lossy().contains("main.go"))
+        );
     }
 
     #[test]
     fn walk_finds_vue_files() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("App.vue"), "<script>export default {}</script>").unwrap();
+        fs::write(
+            dir.path().join("App.vue"),
+            "<script>export default {}</script>",
+        )
+        .unwrap();
         fs::write(dir.path().join("main.ts"), "import App from './App.vue'").unwrap();
         let files = walk_directory(dir.path(), None, &[]).unwrap();
         assert_eq!(files.len(), 2);
@@ -563,7 +655,11 @@ mod tests {
     #[test]
     fn walk_finds_svelte_files() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("Counter.svelte"), "<script>let count = 0</script>").unwrap();
+        fs::write(
+            dir.path().join("Counter.svelte"),
+            "<script>let count = 0</script>",
+        )
+        .unwrap();
         let files = walk_directory(dir.path(), None, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].ends_with("Counter.svelte"));
@@ -572,7 +668,11 @@ mod tests {
     #[test]
     fn walk_finds_astro_files() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("index.astro"), "---\nconst title = 'hi'\n---\n<h1>{title}</h1>").unwrap();
+        fs::write(
+            dir.path().join("index.astro"),
+            "---\nconst title = 'hi'\n---\n<h1>{title}</h1>",
+        )
+        .unwrap();
         let files = walk_directory(dir.path(), None, &[]).unwrap();
         assert_eq!(files.len(), 1);
         assert!(files[0].ends_with("index.astro"));
@@ -581,7 +681,11 @@ mod tests {
     #[test]
     fn walk_ext_filter_vue() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("App.vue"), "<script>export default {}</script>").unwrap();
+        fs::write(
+            dir.path().join("App.vue"),
+            "<script>export default {}</script>",
+        )
+        .unwrap();
         fs::write(dir.path().join("main.ts"), "import App from './App.vue'").unwrap();
         let exts = vec!["vue".to_string()];
         let files = walk_directory(dir.path(), None, &exts).unwrap();
@@ -604,7 +708,11 @@ mod tests {
     #[test]
     fn detect_monorepo_source_roots_finds_inner_src() {
         let dir = TempDir::new().unwrap();
-        fs::write(dir.path().join("package.json"), r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"workspaces": ["packages/*"]}"#,
+        )
+        .unwrap();
         fs::create_dir_all(dir.path().join("packages/foo/src")).unwrap();
         fs::create_dir_all(dir.path().join("packages/bar/lib")).unwrap();
         fs::create_dir_all(dir.path().join("packages/baz")).unwrap(); // no src/lib

--- a/src/xrefs.rs
+++ b/src/xrefs.rs
@@ -138,13 +138,13 @@ pub fn find_xrefs(path: &str, options: &XrefOptions) -> Result<Vec<Reference>, C
 
     for (file_refs, edges, has_def) in &per_file_results {
         if !file_refs.is_empty()
-            && let Some(first) = file_refs.first() {
-                seen_files.insert(PathBuf::from(&first.file));
-            }
-        if *has_def
-            && let Some(first) = file_refs.first() {
-                def_files.insert(PathBuf::from(&first.file));
-            }
+            && let Some(first) = file_refs.first()
+        {
+            seen_files.insert(PathBuf::from(&first.file));
+        }
+        if *has_def && let Some(first) = file_refs.first() {
+            def_files.insert(PathBuf::from(&first.file));
+        }
         all_refs.extend(file_refs.iter().cloned());
         import_edges.extend(edges.iter().cloned());
     }
@@ -163,7 +163,9 @@ pub fn find_xrefs(path: &str, options: &XrefOptions) -> Result<Vec<Reference>, C
                 let points_to_def = if let Some(ref resolved) = edge.resolved_path {
                     def_files.contains(resolved)
                 } else {
-                    def_files.iter().any(|def| source_matches_file(&edge.source, def, path))
+                    def_files
+                        .iter()
+                        .any(|def| source_matches_file(&edge.source, def, path))
                 };
                 if !points_to_def {
                     return false;
@@ -257,7 +259,11 @@ fn find_method_xrefs(path: &Path, options: &XrefOptions) -> Result<Vec<Reference
         return Err(CodehudError::InvalidPath(path.display().to_string()));
     };
 
-    let _root = if path.is_dir() { path } else { path.parent().unwrap_or(path) };
+    let _root = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(path)
+    };
 
     let max_results = options.max_results.unwrap_or(usize::MAX);
     let result_count = AtomicUsize::new(0);
@@ -283,20 +289,31 @@ fn find_method_xrefs(path: &Path, options: &XrefOptions) -> Result<Vec<Reference
             // Use LanguageHandler to find method definition in the parent class
             if let Some(handler) = crate::handler::handler_for(language)
                 && let Some(items) = crate::dispatch::expand_symbol(
-                    &source, &tree, handler.as_ref(), language,
+                    &source,
+                    &tree,
+                    handler.as_ref(),
+                    language,
                     &format!("{}.{}", parent_name, method_name),
-                ) {
-                    for item in &items {
-                        refs.push(Reference {
-                            file: file_str.to_string(),
-                            line: item.line_start,
-                            column: 0,
-                            kind: RefKind::Definition,
-                            line_content: lines.get(item.line_start.saturating_sub(1)).unwrap_or(&"").to_string(),
-                            context: get_context(&lines, item.line_start.saturating_sub(1), options.context_lines),
-                        });
-                    }
+                )
+            {
+                for item in &items {
+                    refs.push(Reference {
+                        file: file_str.to_string(),
+                        line: item.line_start,
+                        column: 0,
+                        kind: RefKind::Definition,
+                        line_content: lines
+                            .get(item.line_start.saturating_sub(1))
+                            .unwrap_or(&"")
+                            .to_string(),
+                        context: get_context(
+                            &lines,
+                            item.line_start.saturating_sub(1),
+                            options.context_lines,
+                        ),
+                    });
                 }
+            }
 
             // Search for member_expression nodes where property == method_name
             find_member_refs(
@@ -373,7 +390,15 @@ fn find_member_refs(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        find_member_refs(&child, source, lines, method_name, file_path, context_lines, refs);
+        find_member_refs(
+            &child,
+            source,
+            lines,
+            method_name,
+            file_path,
+            context_lines,
+            refs,
+        );
     }
 }
 
@@ -398,10 +423,7 @@ fn get_context(lines: &[&str], idx: usize, context_lines: usize) -> Vec<String> 
 }
 
 /// Parse import statements from all supported files in a directory.
-fn parse_all_imports(
-    root: &Path,
-    files: &[PathBuf],
-) -> Result<Vec<ImportEdge>, CodehudError> {
+fn parse_all_imports(root: &Path, files: &[PathBuf]) -> Result<Vec<ImportEdge>, CodehudError> {
     let mut edges = Vec::new();
 
     for file_path in files {
@@ -479,10 +501,11 @@ pub fn parse_js_ts_imports_impl(
 
         // Try source field
         if source_path.is_empty()
-            && let Some(src_node) = child.child_by_field_name("source") {
-                let text = node_text(&src_node, source);
-                source_path = text.trim_matches(|c| c == '\'' || c == '"').to_string();
-            }
+            && let Some(src_node) = child.child_by_field_name("source")
+        {
+            let text = node_text(&src_node, source);
+            source_path = text.trim_matches(|c| c == '\'' || c == '"').to_string();
+        }
 
         if !source_path.is_empty() {
             let resolved = resolve_js_ts_path(file_path, &source_path, project_root);
@@ -546,7 +569,17 @@ fn resolve_js_ts_path(
     let base = dir.join(source);
 
     // Try exact, then with extensions
-    let extensions = ["", ".ts", ".tsx", ".js", ".jsx", "/index.ts", "/index.tsx", "/index.js", "/index.jsx"];
+    let extensions = [
+        "",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        "/index.ts",
+        "/index.tsx",
+        "/index.js",
+        "/index.jsx",
+    ];
     for ext in &extensions {
         let candidate = if ext.is_empty() {
             base.clone()
@@ -562,11 +595,7 @@ fn resolve_js_ts_path(
 }
 
 /// Parse Rust `use` statements (public for use by extractors).
-pub fn parse_rust_imports_impl(
-    root: &Node,
-    source: &str,
-    file_path: &Path,
-) -> Vec<ImportEdge> {
+pub fn parse_rust_imports_impl(root: &Node, source: &str, file_path: &Path) -> Vec<ImportEdge> {
     let mut edges = Vec::new();
     let mut cursor = root.walk();
 
@@ -629,11 +658,7 @@ fn collect_rust_use_symbols(node: &Node, source: &str, symbols: &mut Vec<String>
 }
 
 /// Parse Python import statements (public for use by extractors).
-pub fn parse_python_imports_impl(
-    root: &Node,
-    source: &str,
-    file_path: &Path,
-) -> Vec<ImportEdge> {
+pub fn parse_python_imports_impl(root: &Node, source: &str, file_path: &Path) -> Vec<ImportEdge> {
     let mut edges = Vec::new();
     let mut cursor = root.walk();
 
@@ -712,9 +737,7 @@ pub fn parse_python_imports_impl(
 
 /// Check if an import source string plausibly refers to a file.
 fn source_matches_file(source: &str, def_file: &Path, root: &Path) -> bool {
-    let relative = def_file
-        .strip_prefix(root)
-        .unwrap_or(def_file);
+    let relative = def_file.strip_prefix(root).unwrap_or(def_file);
     let rel_str = relative.to_string_lossy();
     let stem = relative.file_stem().unwrap_or_default().to_string_lossy();
 
@@ -768,7 +791,10 @@ mod tests {
         // Make it look like a project root
         fs::create_dir_all(dir.path().join(".git")).unwrap();
 
-        write_file(dir, "utils.ts", r#"
+        write_file(
+            dir,
+            "utils.ts",
+            r#"
 export function greet(name: string): string {
     return `Hello, ${name}`;
 }
@@ -776,22 +802,31 @@ export function greet(name: string): string {
 export interface Config {
     debug: boolean;
 }
-"#);
+"#,
+        );
 
-        write_file(dir, "app.ts", r#"
+        write_file(
+            dir,
+            "app.ts",
+            r#"
 import { greet, Config } from './utils';
 
 const config: Config = { debug: true };
 console.log(greet("world"));
-"#);
+"#,
+        );
 
-        write_file(dir, "other.ts", r#"
+        write_file(
+            dir,
+            "other.ts",
+            r#"
 function greet() {
     // Different greet, not imported
     return "hi";
 }
 greet();
-"#);
+"#,
+        );
     }
 
     #[test]
@@ -799,12 +834,7 @@ greet();
         let dir = TempDir::new().unwrap();
         setup_ts_project(&dir);
 
-        let edges = get_import_graph(
-            dir.path().to_str().unwrap(),
-            None,
-            &[],
-        )
-        .unwrap();
+        let edges = get_import_graph(dir.path().to_str().unwrap(), None, &[]).unwrap();
 
         // Should find import edge from app.ts
         let app_edges: Vec<_> = edges
@@ -842,12 +872,27 @@ greet();
         let refs = find_xrefs(dir.path().to_str().unwrap(), &opts).unwrap();
 
         // Should find: def in utils.ts, ref in app.ts (import + call), def+ref in other.ts
-        let files: HashSet<String> = refs.iter().map(|r| {
-            Path::new(&r.file).file_name().unwrap().to_string_lossy().to_string()
-        }).collect();
+        let files: HashSet<String> = refs
+            .iter()
+            .map(|r| {
+                Path::new(&r.file)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .collect();
 
-        assert!(files.contains("utils.ts"), "Should find definition in utils.ts, got: {:?}", files);
-        assert!(files.contains("app.ts"), "Should find usage in app.ts, got: {:?}", files);
+        assert!(
+            files.contains("utils.ts"),
+            "Should find definition in utils.ts, got: {:?}",
+            files
+        );
+        assert!(
+            files.contains("app.ts"),
+            "Should find usage in app.ts, got: {:?}",
+            files
+        );
     }
 
     #[test]
@@ -856,7 +901,11 @@ greet();
         fs::create_dir_all(dir.path().join(".git")).unwrap();
 
         write_file(&dir, "lib.rs", "pub fn helper() {}\n");
-        write_file(&dir, "main.rs", "use crate::helper;\nfn main() { helper(); }\n");
+        write_file(
+            &dir,
+            "main.rs",
+            "use crate::helper;\nfn main() { helper(); }\n",
+        );
 
         let edges = get_import_graph(dir.path().to_str().unwrap(), None, &[]).unwrap();
 
@@ -888,8 +937,16 @@ greet();
             .collect();
         assert!(!main_edges.is_empty());
         let all_syms: Vec<_> = main_edges.iter().flat_map(|e| &e.symbols).collect();
-        assert!(all_syms.contains(&&"Foo".to_string()), "Should find Foo: {:?}", all_syms);
-        assert!(all_syms.contains(&&"Bar".to_string()), "Should find Bar: {:?}", all_syms);
+        assert!(
+            all_syms.contains(&&"Foo".to_string()),
+            "Should find Foo: {:?}",
+            all_syms
+        );
+        assert!(
+            all_syms.contains(&&"Bar".to_string()),
+            "Should find Bar: {:?}",
+            all_syms
+        );
     }
 
     #[test]
@@ -939,7 +996,11 @@ greet();
         fs::create_dir_all(dir.path().join(".git")).unwrap();
 
         write_file(&dir, "utils.ts", "export function greet() {}\n");
-        write_file(&dir, "app.ts", "import * as utils from './utils';\nutils.greet();\n");
+        write_file(
+            &dir,
+            "app.ts",
+            "import * as utils from './utils';\nutils.greet();\n",
+        );
 
         let edges = get_import_graph(dir.path().to_str().unwrap(), None, &[]).unwrap();
 
@@ -957,7 +1018,11 @@ greet();
         fs::create_dir_all(dir.path().join(".git")).unwrap();
 
         write_file(&dir, "utils.ts", "export function helper() {}\n");
-        write_file(&dir, "app.ts", "import { helper } from './utils';\nhelper();\n");
+        write_file(
+            &dir,
+            "app.ts",
+            "import { helper } from './utils';\nhelper();\n",
+        );
 
         let edges = get_import_graph(dir.path().to_str().unwrap(), None, &[]).unwrap();
 
@@ -977,19 +1042,27 @@ greet();
         let dir = TempDir::new().unwrap();
         fs::create_dir_all(dir.path().join(".git")).unwrap();
 
-        write_file(&dir, "workflow.ts", r#"
+        write_file(
+            &dir,
+            "workflow.ts",
+            r#"
 export class Workflow {
     getStartNode() {
         return this.getStartNode();
     }
 }
-"#);
+"#,
+        );
 
-        write_file(&dir, "app.ts", r#"
+        write_file(
+            &dir,
+            "app.ts",
+            r#"
 import { Workflow } from './workflow';
 const w = new Workflow();
 w.getStartNode();
-"#);
+"#,
+        );
 
         let opts = XrefOptions {
             symbol: "Workflow.getStartNode".to_string(),
@@ -1014,12 +1087,16 @@ w.getStartNode();
     #[test]
     fn test_new_expression_is_reference() {
         let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.ts", r#"
+        let path = write_file(
+            &dir,
+            "test.ts",
+            r#"
 class Workflow {
     run() {}
 }
 const w = new Workflow();
-"#);
+"#,
+        );
 
         let opts = ReferenceOptions {
             symbol: "Workflow".to_string(),
@@ -1036,6 +1113,10 @@ const w = new Workflow();
         // "new Workflow()" should be Reference, not Definition
         let new_ref = refs.iter().find(|r| r.line == 5);
         assert!(new_ref.is_some(), "Should find Workflow on line 5");
-        assert_eq!(new_ref.unwrap().kind, RefKind::Reference, "new Workflow() should be a Reference");
+        assert_eq!(
+            new_ref.unwrap().kind,
+            RefKind::Reference,
+            "new Workflow() should be a Reference"
+        );
     }
 }

--- a/tests/compact_test.rs
+++ b/tests/compact_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 fn outline_options(compact: bool) -> ProcessOptions {
     ProcessOptions {
@@ -26,6 +26,7 @@ fn outline_options(compact: bool) -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -33,26 +34,46 @@ fn outline_options(compact: bool) -> ProcessOptions {
 fn compact_outline_collapses_params_rust() {
     let output = process_path("tests/fixtures/sample.rs", outline_options(true)).unwrap();
     // Compact mode should show fn new(…) not fn new(name: String, age: u32, email: String)
-    assert!(output.contains("(…)"), "compact should collapse params to …: {}", output);
-    assert!(!output.contains("name: String"), "compact should not show param details: {}", output);
+    assert!(
+        output.contains("(…)"),
+        "compact should collapse params to …: {}",
+        output
+    );
+    assert!(
+        !output.contains("name: String"),
+        "compact should not show param details: {}",
+        output
+    );
 }
 
 #[test]
 fn normal_outline_shows_full_params_rust() {
     let output = process_path("tests/fixtures/sample.rs", outline_options(false)).unwrap();
     // Normal mode should show full params
-    assert!(output.contains("name: String"), "normal outline should show param details: {}", output);
+    assert!(
+        output.contains("name: String"),
+        "normal outline should show param details: {}",
+        output
+    );
 }
 
 #[test]
 fn compact_outline_strips_docstrings() {
     let output = process_path("tests/fixtures/sample.rs", outline_options(true)).unwrap();
     // Docstrings like "/// A sample struct" should be stripped
-    assert!(!output.contains("/// A sample struct"), "compact should strip docstrings: {}", output);
+    assert!(
+        !output.contains("/// A sample struct"),
+        "compact should strip docstrings: {}",
+        output
+    );
 }
 
 #[test]
 fn compact_outline_ts() {
     let output = process_path("tests/fixtures/sample.ts", outline_options(true)).unwrap();
-    assert!(output.contains("(…)") || output.contains("()"), "compact should work for TS: {}", output);
+    assert!(
+        output.contains("(…)") || output.contains("()"),
+        "compact should work for TS: {}",
+        output
+    );
 }

--- a/tests/cpp_test.rs
+++ b/tests/cpp_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -92,7 +94,10 @@ fn cpp_list_symbols() {
     assert!(text.contains("MyClass"), "should find MyClass: {text}");
     assert!(text.contains("MyStruct"), "should find MyStruct: {text}");
     assert!(text.contains("Color"), "should find Color: {text}");
-    assert!(text.contains("free_function"), "should find free_function: {text}");
+    assert!(
+        text.contains("free_function"),
+        "should find free_function: {text}"
+    );
     assert!(text.contains("myns"), "should find namespace myns: {text}");
 }
 
@@ -104,7 +109,10 @@ fn cpp_list_symbols_no_imports() {
     opts.no_imports = true;
     let text = run(&f, opts);
     assert!(!text.contains("#include"), "should hide includes: {text}");
-    assert!(text.contains("MyClass"), "should still show MyClass: {text}");
+    assert!(
+        text.contains("MyClass"),
+        "should still show MyClass: {text}"
+    );
 }
 
 #[test]
@@ -124,7 +132,10 @@ fn cpp_fns_filter() {
     opts.list_symbols = true;
     opts.fns_only = true;
     let text = run(&f, opts);
-    assert!(text.contains("free_function") || text.contains("add"), "should show functions: {text}");
+    assert!(
+        text.contains("free_function") || text.contains("add"),
+        "should show functions: {text}"
+    );
     assert!(!text.contains("MyStruct"), "should hide structs: {text}");
 }
 
@@ -135,8 +146,10 @@ fn cpp_types_filter() {
     opts.list_symbols = true;
     opts.types_only = true;
     let text = run(&f, opts);
-    assert!(text.contains("MyClass") || text.contains("MyStruct") || text.contains("Color"),
-        "should show types: {text}");
+    assert!(
+        text.contains("MyClass") || text.contains("MyStruct") || text.contains("Color"),
+        "should show types: {text}"
+    );
 }
 
 #[test]
@@ -156,7 +169,10 @@ fn cpp_json_output() {
     opts.format = OutputFormat::Json;
     let text = run(&f, opts);
     let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert!(parsed.is_array() || parsed.is_object(), "should produce valid JSON: {text}");
+    assert!(
+        parsed.is_array() || parsed.is_object(),
+        "should produce valid JSON: {text}"
+    );
 }
 
 #[test]
@@ -166,7 +182,10 @@ fn cpp_depth2_shows_members() {
     opts.list_symbols = true;
     opts.symbol_depth = Some(2);
     let text = run(&f, opts);
-    assert!(text.contains("method"), "depth 2 should show class methods: {text}");
+    assert!(
+        text.contains("method"),
+        "depth 2 should show class methods: {text}"
+    );
 }
 
 #[test]
@@ -181,7 +200,10 @@ T maximum(T a, T b) {
     let mut opts = opts();
     opts.list_symbols = true;
     let text = run(&f, opts);
-    assert!(text.contains("maximum"), "should detect template function: {text}");
+    assert!(
+        text.contains("maximum"),
+        "should detect template function: {text}"
+    );
 }
 
 #[test]
@@ -193,7 +215,10 @@ enum class Direction { North, South, East, West };
     let mut opts = opts();
     opts.list_symbols = true;
     let text = run(&f, opts);
-    assert!(text.contains("Direction"), "should detect enum class: {text}");
+    assert!(
+        text.contains("Direction"),
+        "should detect enum class: {text}"
+    );
 }
 
 #[test]
@@ -202,5 +227,8 @@ fn cpp_stats_mode() {
     let mut opts = opts();
     opts.stats = true;
     let text = run(&f, opts);
-    assert!(text.contains("C++"), "stats should show C++ language: {text}");
+    assert!(
+        text.contains("C++"),
+        "stats should show C++ language: {text}"
+    );
 }

--- a/tests/csharp_test.rs
+++ b/tests/csharp_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -113,7 +115,10 @@ fn csharp_interface_mode_basic() {
     assert!(output.contains("using"), "Missing using directive");
     assert!(output.contains("namespace"), "Missing namespace");
     assert!(output.contains("class UserService"), "Missing class");
-    assert!(output.contains("interface IRepository"), "Missing interface");
+    assert!(
+        output.contains("interface IRepository"),
+        "Missing interface"
+    );
     assert!(output.contains("enum Status"), "Missing enum");
     assert!(output.contains("struct Point"), "Missing struct");
     assert!(output.contains("record Person"), "Missing record");
@@ -130,7 +135,10 @@ fn csharp_expand_class() {
 
     assert!(output.contains("class UserService"), "Missing class");
     assert!(output.contains("GetUser"), "Missing GetUser method");
-    assert!(output.contains("RefreshCache"), "Missing RefreshCache method");
+    assert!(
+        output.contains("RefreshCache"),
+        "Missing RefreshCache method"
+    );
     assert!(output.contains("Create"), "Missing static method");
 }
 
@@ -158,8 +166,14 @@ fn csharp_types_filter() {
     o.types_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("class UserService"), "Missing class as type");
-    assert!(output.contains("interface IRepository"), "Missing interface as type");
+    assert!(
+        output.contains("class UserService"),
+        "Missing class as type"
+    );
+    assert!(
+        output.contains("interface IRepository"),
+        "Missing interface as type"
+    );
     assert!(output.contains("enum Status"), "Missing enum as type");
 }
 
@@ -224,7 +238,10 @@ internal class InternalHelper
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("class UserService"), "Missing public class");
-    assert!(!output.contains("InternalHelper"), "Internal class should be hidden");
+    assert!(
+        !output.contains("InternalHelper"),
+        "Internal class should be hidden"
+    );
 }
 
 // --- Using directives ---
@@ -235,5 +252,8 @@ fn csharp_usings() {
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
     assert!(output.contains("using System;"), "Missing System using");
-    assert!(output.contains("using System.Collections.Generic"), "Missing Collections using");
+    assert!(
+        output.contains("using System.Collections.Generic"),
+        "Missing Collections using"
+    );
 }

--- a/tests/diff_test.rs
+++ b/tests/diff_test.rs
@@ -64,7 +64,10 @@ fn test_diff_added_function() {
 
     let out = codehud_in(p, &["--diff", "HEAD", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("new_func"), "expected new_func in output: {stdout}");
+    assert!(
+        stdout.contains("new_func"),
+        "expected new_func in output: {stdout}"
+    );
     assert!(stdout.contains("+"), "expected + marker for added symbol");
 }
 
@@ -78,7 +81,10 @@ fn test_diff_deleted_function() {
 
     let out = codehud_in(p, &["--diff", "HEAD", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("world"), "expected world in deleted output: {stdout}");
+    assert!(
+        stdout.contains("world"),
+        "expected world in deleted output: {stdout}"
+    );
     assert!(stdout.contains("-"), "expected - marker for deleted symbol");
 }
 
@@ -96,8 +102,14 @@ fn test_diff_modified_function() {
 
     let out = codehud_in(p, &["--diff", "HEAD", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("hello"), "expected hello in modified output: {stdout}");
-    assert!(stdout.contains("~"), "expected ~ marker for modified symbol");
+    assert!(
+        stdout.contains("hello"),
+        "expected hello in modified output: {stdout}"
+    );
+    assert!(
+        stdout.contains("~"),
+        "expected ~ marker for modified symbol"
+    );
 }
 
 #[test]
@@ -114,7 +126,10 @@ fn test_diff_new_file() {
     let out = codehud_in(p, &["--diff", "HEAD", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
     // Untracked files should NOT appear
-    assert!(!stdout.contains("brand_new"), "untracked file should not appear in diff");
+    assert!(
+        !stdout.contains("brand_new"),
+        "untracked file should not appear in diff"
+    );
 }
 
 #[test]
@@ -192,7 +207,10 @@ fn test_staged_new_file() {
 
     let out = codehud_in(p, &["--diff", "--staged", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("brand_new"), "expected brand_new in staged new file: {stdout}");
+    assert!(
+        stdout.contains("brand_new"),
+        "expected brand_new in staged new file: {stdout}"
+    );
 }
 
 #[test]
@@ -204,7 +222,10 @@ fn test_staged_deleted_file() {
 
     let out = codehud_in(p, &["--diff", "--staged", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("hello"), "expected deleted symbols: {stdout}");
+    assert!(
+        stdout.contains("hello"),
+        "expected deleted symbols: {stdout}"
+    );
     assert!(stdout.contains("-"), "expected - marker for deleted");
 }
 
@@ -225,8 +246,8 @@ fn test_diff_json_output() {
 
     let out = codehud_in(p, &["--diff", "HEAD", "--json", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
     assert!(parsed.is_array(), "expected JSON array");
     let arr = parsed.as_array().unwrap();
     assert!(!arr.is_empty(), "expected at least one entry");
@@ -252,11 +273,14 @@ fn test_staged_json_output() {
 
     let out = codehud_in(p, &["--diff", "--staged", "--json", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{stdout}"));
     assert!(parsed.is_array());
     let arr = parsed.as_array().unwrap();
-    assert!(arr.iter().any(|e| e["change_type"] == "modified"), "expected modified entry");
+    assert!(
+        arr.iter().any(|e| e["change_type"] == "modified"),
+        "expected modified entry"
+    );
 }
 
 // -------------------------------------------------------------------------
@@ -274,7 +298,11 @@ fn test_diff_ext_filter() {
     git(p, &["commit", "-m", "add py"]);
 
     // Now modify both
-    fs::write(p.join("script.py"), "def new_py():\n    return 1\ndef another():\n    pass\n").unwrap();
+    fs::write(
+        p.join("script.py"),
+        "def new_py():\n    return 1\ndef another():\n    pass\n",
+    )
+    .unwrap();
     fs::write(
         p.join("lib.rs"),
         "fn hello() { println!(\"changed\"); }\n\nfn world() { println!(\"world\"); }\n",
@@ -369,7 +397,11 @@ fn test_diff_binary_file_no_crash() {
     let p = dir.path();
 
     // Add a binary file
-    fs::write(p.join("image.png"), &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]).unwrap();
+    fs::write(
+        p.join("image.png"),
+        &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    )
+    .unwrap();
     git(p, &["add", "image.png"]);
     git(p, &["commit", "-m", "add binary"]);
 
@@ -405,7 +437,10 @@ fn test_diff_typescript() {
 
     let out = codehud_in(p, &["--diff", "HEAD", "."]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("farewell"), "expected farewell added: {stdout}");
+    assert!(
+        stdout.contains("farewell"),
+        "expected farewell added: {stdout}"
+    );
 }
 
 // -------------------------------------------------------------------------

--- a/tests/dispatch_tests.rs
+++ b/tests/dispatch_tests.rs
@@ -1,5 +1,5 @@
 use codehud::dispatch;
-use codehud::handler::{self, ItemKind, Visibility, Language, ts_language};
+use codehud::handler::{self, ItemKind, Language, Visibility, ts_language};
 
 const TS_SOURCE: &str = r#"
 import { Something } from './somewhere';
@@ -59,15 +59,42 @@ fn list_symbols_top_level() {
     let items = dispatch::list_symbols(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, 1);
 
     let names: Vec<Option<&str>> = items.iter().map(|i| i.name.as_deref()).collect();
-    assert!(names.contains(&Some("MyClass")), "should contain MyClass, got: {:?}", names);
-    assert!(names.contains(&Some("localFunction")), "should contain localFunction, got: {:?}", names);
-    assert!(names.contains(&Some("MyInterface")), "should contain MyInterface, got: {:?}", names);
-    assert!(names.contains(&Some("MyType")), "should contain MyType, got: {:?}", names);
-    assert!(names.contains(&Some("MY_CONST")), "should contain MY_CONST, got: {:?}", names);
-    assert!(names.contains(&Some("Color")), "should contain Color, got: {:?}", names);
+    assert!(
+        names.contains(&Some("MyClass")),
+        "should contain MyClass, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("localFunction")),
+        "should contain localFunction, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("MyInterface")),
+        "should contain MyInterface, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("MyType")),
+        "should contain MyType, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("MY_CONST")),
+        "should contain MY_CONST, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("Color")),
+        "should contain Color, got: {:?}",
+        names
+    );
 
     // Imports should be excluded
-    assert!(!items.iter().any(|i| i.kind == ItemKind::Use), "imports should be excluded");
+    assert!(
+        !items.iter().any(|i| i.kind == ItemKind::Use),
+        "imports should be excluded"
+    );
 }
 
 #[test]
@@ -76,10 +103,16 @@ fn list_symbols_visibility() {
     let handler = get_handler();
     let items = dispatch::list_symbols(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, 1);
 
-    let my_class = items.iter().find(|i| i.name.as_deref() == Some("MyClass")).unwrap();
+    let my_class = items
+        .iter()
+        .find(|i| i.name.as_deref() == Some("MyClass"))
+        .unwrap();
     assert_eq!(my_class.visibility, Visibility::Public);
 
-    let local_fn = items.iter().find(|i| i.name.as_deref() == Some("localFunction")).unwrap();
+    let local_fn = items
+        .iter()
+        .find(|i| i.name.as_deref() == Some("localFunction"))
+        .unwrap();
     assert_eq!(local_fn.visibility, Visibility::Private);
 }
 
@@ -91,17 +124,35 @@ fn list_symbols_depth2_includes_children() {
 
     let names: Vec<Option<&str>> = items.iter().map(|i| i.name.as_deref()).collect();
     // Should include child methods
-    assert!(names.contains(&Some("getStartNode")), "depth 2 should include getStartNode, got: {:?}", names);
-    assert!(names.contains(&Some("helperMethod")), "depth 2 should include helperMethod, got: {:?}", names);
+    assert!(
+        names.contains(&Some("getStartNode")),
+        "depth 2 should include getStartNode, got: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&Some("helperMethod")),
+        "depth 2 should include helperMethod, got: {:?}",
+        names
+    );
     // Interface property members
-    assert!(names.contains(&Some("id")), "depth 2 should include interface property 'id', got: {:?}", names);
+    assert!(
+        names.contains(&Some("id")),
+        "depth 2 should include interface property 'id', got: {:?}",
+        names
+    );
 }
 
 #[test]
 fn expand_symbol_class() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let result = dispatch::expand_symbol(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "MyClass");
+    let result = dispatch::expand_symbol(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "MyClass",
+    );
     assert!(result.is_some());
     let items = result.unwrap();
     assert_eq!(items.len(), 1);
@@ -113,20 +164,35 @@ fn expand_symbol_class() {
 fn expand_symbol_qualified_method() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let result = dispatch::expand_symbol(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "MyClass.getStartNode");
+    let result = dispatch::expand_symbol(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "MyClass.getStartNode",
+    );
     assert!(result.is_some());
     let items = result.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].kind, ItemKind::Method);
     assert!(items[0].content.contains("getStartNode"));
-    assert!(!items[0].content.contains("helperMethod"), "should only contain the method, not the whole class");
+    assert!(
+        !items[0].content.contains("helperMethod"),
+        "should only contain the method, not the whole class"
+    );
 }
 
 #[test]
 fn expand_symbol_nonexistent_member() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let result = dispatch::expand_symbol(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "MyClass.nonExistent");
+    let result = dispatch::expand_symbol(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "MyClass.nonExistent",
+    );
     assert!(result.is_none());
 }
 
@@ -134,7 +200,13 @@ fn expand_symbol_nonexistent_member() {
 fn expand_symbol_nonexistent_root() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let result = dispatch::expand_symbol(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "NoSuchClass");
+    let result = dispatch::expand_symbol(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "NoSuchClass",
+    );
     assert!(result.is_none());
 }
 
@@ -142,7 +214,13 @@ fn expand_symbol_nonexistent_root() {
 fn find_unqualified_member_finds_method() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let results = dispatch::find_unqualified_member(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "getStartNode");
+    let results = dispatch::find_unqualified_member(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "getStartNode",
+    );
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].kind, ItemKind::Method);
     assert!(results[0].content.contains("getStartNode"));
@@ -152,7 +230,13 @@ fn find_unqualified_member_finds_method() {
 fn find_unqualified_member_not_found() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let results = dispatch::find_unqualified_member(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "nonExistent");
+    let results = dispatch::find_unqualified_member(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "nonExistent",
+    );
     assert!(results.is_empty());
 }
 
@@ -160,7 +244,13 @@ fn find_unqualified_member_not_found() {
 fn expand_symbol_double_colon_notation() {
     let tree = parse_ts(TS_SOURCE);
     let handler = get_handler();
-    let result = dispatch::expand_symbol(TS_SOURCE, &tree, handler.as_ref(), Language::TypeScript, "MyClass::getStartNode");
+    let result = dispatch::expand_symbol(
+        TS_SOURCE,
+        &tree,
+        handler.as_ref(),
+        Language::TypeScript,
+        "MyClass::getStartNode",
+    );
     assert!(result.is_some());
     assert_eq!(result.unwrap()[0].kind, ItemKind::Method);
 }

--- a/tests/display_names_test.rs
+++ b/tests/display_names_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 fn list_options() -> ProcessOptions {
     ProcessOptions {
@@ -9,7 +9,8 @@ fn list_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -25,6 +26,7 @@ fn list_options() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -32,23 +34,43 @@ fn list_options() -> ProcessOptions {
 fn ts_list_symbols_shows_interface_not_trait() {
     let output = process_path("tests/fixtures/sample.ts", list_options()).unwrap();
     // TS interfaces should display as "interface", not "trait"
-    assert!(output.contains("interface"), "Expected 'interface' in TS output, got:\n{}", output);
-    assert!(!output.contains(" trait "), "Should not contain 'trait' for TS files, got:\n{}", output);
+    assert!(
+        output.contains("interface"),
+        "Expected 'interface' in TS output, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains(" trait "),
+        "Should not contain 'trait' for TS files, got:\n{}",
+        output
+    );
 }
 
 #[test]
 fn ts_list_symbols_shows_import_not_use() {
     let output = process_path("tests/fixtures/sample.ts", list_options()).unwrap();
-    assert!(output.contains("import"), "Expected 'import' in TS output, got:\n{}", output);
+    assert!(
+        output.contains("import"),
+        "Expected 'import' in TS output, got:\n{}",
+        output
+    );
     // Should not have bare "use " as a kind label
     let has_use_label = output.lines().any(|l| l.trim_start().starts_with("use "));
-    assert!(!has_use_label, "Should not show 'use' kind for TS files, got:\n{}", output);
+    assert!(
+        !has_use_label,
+        "Should not show 'use' kind for TS files, got:\n{}",
+        output
+    );
 }
 
 #[test]
 fn ts_list_symbols_shows_type_alias() {
     let output = process_path("tests/fixtures/sample.ts", list_options()).unwrap();
-    assert!(output.contains("type alias"), "Expected 'type alias' in TS output, got:\n{}", output);
+    assert!(
+        output.contains("type alias"),
+        "Expected 'type alias' in TS output, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -59,14 +81,30 @@ fn ts_json_output_uses_ts_display_names() {
         ..list_options()
     };
     let output = process_path("tests/fixtures/sample.ts", options).unwrap();
-    assert!(output.contains("\"interface\""), "Expected 'interface' kind in JSON, got:\n{}", output);
-    assert!(output.contains("\"import\""), "Expected 'import' kind in JSON, got:\n{}", output);
-    assert!(output.contains("\"type alias\""), "Expected 'type alias' kind in JSON, got:\n{}", output);
+    assert!(
+        output.contains("\"interface\""),
+        "Expected 'interface' kind in JSON, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("\"import\""),
+        "Expected 'import' kind in JSON, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("\"type alias\""),
+        "Expected 'type alias' kind in JSON, got:\n{}",
+        output
+    );
 }
 
 #[test]
 fn rust_list_symbols_still_shows_trait() {
     let output = process_path("tests/fixtures/sample.rs", list_options()).unwrap();
     // Rust files should still use Rust terminology
-    assert!(output.contains("trait "), "Rust files should still show 'trait', got:\n{}", output);
+    assert!(
+        output.contains("trait "),
+        "Rust files should still show 'trait', got:\n{}",
+        output
+    );
 }

--- a/tests/doc_comments_test.rs
+++ b/tests/doc_comments_test.rs
@@ -1,0 +1,139 @@
+use codehud::{OutputFormat, ProcessOptions, process_path};
+
+fn opts_with_comments() -> ProcessOptions {
+    ProcessOptions {
+        symbols: vec![],
+        pub_only: false,
+        fns_only: false,
+        types_only: false,
+        no_tests: false,
+        depth: None,
+        format: OutputFormat::Json,
+        stats: false,
+        stats_detailed: true,
+        ext: vec![],
+        signatures: false,
+        max_lines: None,
+        list_symbols: false,
+        no_imports: false,
+        smart_depth: false,
+        symbol_depth: None,
+        exclude: vec![],
+        outline: false,
+        compact: false,
+        minimal: false,
+        yes: false,
+        warn_threshold: 10_000,
+        expand_symbols: vec![],
+        token_budget: None,
+        with_comments: true,
+    }
+}
+
+#[test]
+fn test_rust_doc_comments() {
+    let result = process_path("tests/fixtures/doc_comments.rs", opts_with_comments()).unwrap();
+    // /// line doc comments on struct
+    assert!(
+        result.contains("This is a documented struct"),
+        "Missing Rust /// doc comment:\n{result}"
+    );
+    // /** block doc comment
+    assert!(
+        result.contains("Block doc comment"),
+        "Missing Rust /** doc comment:\n{result}"
+    );
+    // Regular // comment should NOT appear as doc_comment
+    assert!(
+        !result.contains("Regular comment, not a doc comment"),
+        "Regular comment leaked:\n{result}"
+    );
+}
+
+#[test]
+fn test_go_doc_comments() {
+    let result = process_path("tests/fixtures/doc_comments.go", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("Greet returns a greeting"),
+        "Missing Go doc comment:\n{result}"
+    );
+}
+
+#[test]
+fn test_python_docstrings() {
+    let result = process_path("tests/fixtures/doc_comments.py", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("This function has a docstring"),
+        "Missing Python docstring:\n{result}"
+    );
+}
+
+#[test]
+fn test_typescript_jsdoc() {
+    let result = process_path("tests/fixtures/doc_comments.ts", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented interface"),
+        "Missing TS JSDoc:\n{result}"
+    );
+    assert!(
+        result.contains("JSDoc on a function"),
+        "Missing TS function JSDoc:\n{result}"
+    );
+}
+
+#[test]
+fn test_javascript_jsdoc() {
+    let result = process_path("tests/fixtures/doc_comments.js", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented function"),
+        "Missing JS JSDoc:\n{result}"
+    );
+}
+
+#[test]
+fn test_java_javadoc() {
+    let result = process_path("tests/fixtures/DocComments.java", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented class"),
+        "Missing Java class JavaDoc:\n{result}"
+    );
+}
+
+#[test]
+fn test_csharp_xml_doc() {
+    let result = process_path("tests/fixtures/DocComments.cs", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented class"),
+        "Missing C# XML doc:\n{result}"
+    );
+}
+
+#[test]
+fn test_kotlin_kdoc() {
+    let result = process_path("tests/fixtures/DocComments.kt", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented class"),
+        "Missing Kotlin KDoc:\n{result}"
+    );
+}
+
+#[test]
+fn test_cpp_doxygen() {
+    let result = process_path("tests/fixtures/doc_comments.cpp", opts_with_comments()).unwrap();
+    assert!(
+        result.contains("A documented function"),
+        "Missing C++ Doxygen:\n{result}"
+    );
+}
+
+#[test]
+fn test_with_comments_false_omits_docs() {
+    let mut opts = opts_with_comments();
+    opts.with_comments = false;
+    let result = process_path("tests/fixtures/doc_comments.rs", opts).unwrap();
+    // doc_comment field should be null/absent
+    assert!(
+        !result.contains("This is a documented struct"),
+        "Doc comment present when with_comments=false:\n{result}"
+    );
+}

--- a/tests/editor_test.rs
+++ b/tests/editor_test.rs
@@ -1,5 +1,5 @@
-use codehud::editor::{self, BatchEdit, BatchAction};
 use codehud::Language;
+use codehud::editor::{self, BatchAction, BatchEdit};
 
 // ============================================================================
 // REPLACE TESTS
@@ -23,7 +23,7 @@ fn world() {
 }"#;
 
     let result = editor::replace(source, "hello", new_content, Language::Rust).unwrap();
-    
+
     assert!(result.contains("Greetings"));
     assert!(result.contains("Modified"));
     assert!(result.contains("fn world()"));
@@ -51,7 +51,7 @@ struct Person {
 }"#;
 
     let result = editor::replace(source, "Person", new_content, Language::Rust).unwrap();
-    
+
     assert!(result.contains("full_name"));
     assert!(result.contains("#[derive(Debug)]"));
     assert!(!result.contains("serde"));
@@ -72,7 +72,7 @@ fn valid() {
 }"#;
 
     let result = editor::replace(source, "valid", invalid_content, Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -87,7 +87,7 @@ fn existing() {
     let new_content = r#"fn new_func() {}"#;
 
     let result = editor::replace(source, "nonexistent", new_content, Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -112,7 +112,7 @@ fn third() {
 "#;
 
     let result = editor::delete(source, "second", Language::Rust).unwrap();
-    
+
     assert!(result.contains("fn first()"));
     assert!(result.contains("fn third()"));
     assert!(!result.contains("fn second()"));
@@ -134,7 +134,7 @@ struct ToKeep {
 "#;
 
     let result = editor::delete(source, "ToDelete", Language::Rust).unwrap();
-    
+
     assert!(!result.contains("ToDelete"));
     assert!(!result.contains("#[derive(Debug, Clone)]"));
     assert!(!result.contains("serde"));
@@ -151,7 +151,7 @@ fn third() {}
 "#;
 
     let result = editor::delete(source, "second", Language::Rust).unwrap();
-    
+
     // Deletion may leave some blank lines, which is acceptable
     assert!(result.contains("fn third()"));
 }
@@ -165,7 +165,7 @@ fn existing() {
 "#;
 
     let result = editor::delete(source, "nonexistent", Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -187,7 +187,7 @@ fn calculate(x: i32, y: i32) -> i32 {
 }"#;
 
     let result = editor::replace_body(source, "calculate", new_body, Language::Rust).unwrap();
-    
+
     // Signature should be preserved
     assert!(result.contains("fn calculate(x: i32, y: i32) -> i32"));
     // New body should be present
@@ -219,7 +219,7 @@ impl Calculator {
     }"#;
 
     let result = editor::replace_body(source, "add", new_body, Language::Rust).unwrap();
-    
+
     assert!(result.contains("fn add(&self, a: i32, b: i32) -> i32"));
     assert!(result.contains(r#"println!("Adding"#));
     assert!(result.contains("fn multiply"));
@@ -239,7 +239,7 @@ fn valid(x: i32) -> i32 {
 }"#;
 
     let result = editor::replace_body(source, "valid", invalid_body, Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -254,7 +254,7 @@ fn existing() {
     let new_body = r#"{ println!("New"); }"#;
 
     let result = editor::replace_body(source, "nonexistent", new_body, Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -297,7 +297,7 @@ fn third() {
     ];
 
     let result = editor::batch(source, &edits, Language::Rust).unwrap();
-    
+
     assert!(result.contains("Modified first"));
     assert!(!result.contains("fn second()"));
     assert!(result.contains("Modified third"));
@@ -329,7 +329,7 @@ impl MyStruct {
     ];
 
     let result = editor::batch(source, &edits, Language::Rust);
-    
+
     // This should error because the ranges overlap
     assert!(result.is_err());
 }
@@ -342,16 +342,14 @@ fn test_func() {
 }
 "#;
 
-    let edits = vec![
-        BatchEdit {
-            symbol: "test_func".to_string(),
-            action: BatchAction::Replace,
-            content: None, // Missing content for Replace
-        },
-    ];
+    let edits = vec![BatchEdit {
+        symbol: "test_func".to_string(),
+        action: BatchAction::Replace,
+        content: None, // Missing content for Replace
+    }];
 
     let result = editor::batch(source, &edits, Language::Rust);
-    
+
     assert!(result.is_err());
 }
 
@@ -366,7 +364,7 @@ fn unchanged() {
     let edits: Vec<BatchEdit> = vec![];
 
     let result = editor::batch(source, &edits, Language::Rust).unwrap();
-    
+
     // Should succeed with no changes
     assert_eq!(result, source);
 }
@@ -392,7 +390,7 @@ function farewell(name: string): string {
 }"#;
 
     let result = editor::replace(source, "greet", new_content, Language::TypeScript).unwrap();
-    
+
     assert!(result.contains("Hi there"));
     assert!(result.contains("${name}"));
     assert!(!result.contains(r#""Hello, ""#));
@@ -420,7 +418,7 @@ class Animal {
 "#;
 
     let result = editor::delete(source, "Person", Language::TypeScript).unwrap();
-    
+
     assert!(!result.contains("class Person"));
     assert!(!result.contains("constructor(name: string)"));
     assert!(result.contains("class Animal"));
@@ -441,13 +439,12 @@ function calculate(x: number, y: number): number {
 }"#;
 
     let result = editor::replace_body(source, "calculate", new_body, Language::TypeScript).unwrap();
-    
+
     assert!(result.contains("function calculate(x: number, y: number): number"));
     assert!(result.contains("x * y"));
     assert!(result.contains("console.log"));
     assert!(!result.contains("x + y"));
 }
-
 
 // ============================================================================
 // PYTHON TESTS

--- a/tests/exclude_test.rs
+++ b/tests/exclude_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 fn default_options() -> ProcessOptions {
     ProcessOptions {
@@ -26,6 +26,7 @@ fn default_options() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -40,9 +41,17 @@ fn setup_test_dir() -> TempDir {
     fs::create_dir_all(dir.path().join("dist")).unwrap();
     fs::create_dir_all(dir.path().join("generated")).unwrap();
 
-    fs::write(dir.path().join("src/main.rs"), "fn main() {}\nfn helper() {}\n").unwrap();
+    fs::write(
+        dir.path().join("src/main.rs"),
+        "fn main() {}\nfn helper() {}\n",
+    )
+    .unwrap();
     fs::write(dir.path().join("dist/bundle.js"), "function main() {}\n").unwrap();
-    fs::write(dir.path().join("generated/types.ts"), "export interface Foo { bar: string; }\n").unwrap();
+    fs::write(
+        dir.path().join("generated/types.ts"),
+        "export interface Foo { bar: string; }\n",
+    )
+    .unwrap();
     dir
 }
 
@@ -58,12 +67,19 @@ fn exclude_single_directory() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
     assert!(output.contains("main.rs"), "should include src/main.rs");
-    assert!(!output.contains("bundle.js"), "should exclude dist/bundle.js");
-    assert!(output.contains("types.ts"), "should include generated/types.ts");
+    assert!(
+        !output.contains("bundle.js"),
+        "should exclude dist/bundle.js"
+    );
+    assert!(
+        output.contains("types.ts"),
+        "should include generated/types.ts"
+    );
 }
 
 #[test]
@@ -78,12 +94,19 @@ fn exclude_multiple_directories() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
     assert!(output.contains("main.rs"), "should include src/main.rs");
-    assert!(!output.contains("bundle.js"), "should exclude dist/bundle.js");
-    assert!(!output.contains("types.ts"), "should exclude generated/types.ts");
+    assert!(
+        !output.contains("bundle.js"),
+        "should exclude dist/bundle.js"
+    );
+    assert!(
+        !output.contains("types.ts"),
+        "should exclude generated/types.ts"
+    );
 }
 
 #[test]
@@ -98,11 +121,15 @@ fn exclude_glob_pattern() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
     assert!(output.contains("main.rs"), "should include .rs files");
-    assert!(!output.contains("bundle.js"), "should exclude .js files via glob");
+    assert!(
+        !output.contains("bundle.js"),
+        "should exclude .js files via glob"
+    );
     assert!(output.contains("types.ts"), "should include .ts files");
 }
 
@@ -120,6 +147,7 @@ fn exclude_with_ext_filter() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
@@ -139,12 +167,15 @@ fn exclude_with_search() {
         no_tests: false,
         exclude: vec!["dist".to_string()],
         json: false,
-            context: None,
-            summary: false,
-            files_first: false,
+        context: None,
+        summary: false,
+        files_first: false,
     };
     let output = codehud::search::search_path(dir.path().to_str().unwrap(), &search_opts).unwrap();
-    assert!(output.contains("main.rs"), "should find main in src/main.rs");
+    assert!(
+        output.contains("main.rs"),
+        "should find main in src/main.rs"
+    );
     assert!(!output.contains("bundle.js"), "should not search in dist/");
 }
 
@@ -157,8 +188,14 @@ fn exclude_with_list_symbols() {
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
-    assert!(output.contains("main"), "should list symbols from src/main.rs");
-    assert!(!output.contains("bundle"), "should not list symbols from dist/");
+    assert!(
+        output.contains("main"),
+        "should list symbols from src/main.rs"
+    );
+    assert!(
+        !output.contains("bundle"),
+        "should not list symbols from dist/"
+    );
 }
 
 #[test]
@@ -186,7 +223,11 @@ fn exclude_wildcard_path_pattern() {
     fs::create_dir_all(dir.path().join("packages/foo/src")).unwrap();
     fs::create_dir_all(dir.path().join("packages/foo/migrations")).unwrap();
     fs::write(dir.path().join("packages/foo/src/lib.rs"), "fn foo() {}\n").unwrap();
-    fs::write(dir.path().join("packages/foo/migrations/001.rs"), "fn migrate() {}\n").unwrap();
+    fs::write(
+        dir.path().join("packages/foo/migrations/001.rs"),
+        "fn migrate() {}\n",
+    )
+    .unwrap();
 
     let options = ProcessOptions {
         exclude: vec!["*/migrations/*".to_string()],
@@ -197,9 +238,13 @@ fn exclude_wildcard_path_pattern() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(dir.path().to_str().unwrap(), options).unwrap();
     assert!(output.contains("lib.rs"), "should include src files");
-    assert!(!output.contains("001.rs"), "should exclude migration files via glob");
+    assert!(
+        !output.contains("001.rs"),
+        "should exclude migration files via glob"
+    );
 }

--- a/tests/fixtures/DocComments.cs
+++ b/tests/fixtures/DocComments.cs
@@ -1,0 +1,15 @@
+/// <summary>
+/// A documented class.
+/// </summary>
+public class DocComments {
+    /// <summary>
+    /// XML doc on a method.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    public string Greet(string name) {
+        return "Hello, " + name;
+    }
+
+    // Regular comment.
+    public void NoDoc() {}
+}

--- a/tests/fixtures/DocComments.java
+++ b/tests/fixtures/DocComments.java
@@ -1,0 +1,16 @@
+/**
+ * A documented class.
+ */
+public class DocComments {
+    /**
+     * JavaDoc on a method.
+     * @param name the name
+     * @return greeting string
+     */
+    public String greet(String name) {
+        return "Hello, " + name;
+    }
+
+    // Not a javadoc comment.
+    public void noDoc() {}
+}

--- a/tests/fixtures/DocComments.kt
+++ b/tests/fixtures/DocComments.kt
@@ -1,0 +1,16 @@
+/**
+ * A documented class.
+ */
+class DocComments {
+    /**
+     * KDoc on a method.
+     * @param name the name
+     * @return greeting
+     */
+    fun greet(name: String): String {
+        return "Hello, $name"
+    }
+
+    // Not a KDoc comment.
+    fun noDoc() {}
+}

--- a/tests/fixtures/doc_comments.cpp
+++ b/tests/fixtures/doc_comments.cpp
@@ -1,0 +1,22 @@
+/**
+ * A documented function.
+ * @param name the name
+ * @return greeting string
+ */
+std::string greet(const std::string& name) {
+    return "Hello, " + name;
+}
+
+// Regular comment, not Doxygen.
+void noDoc() {}
+
+/**
+ * Documented class.
+ */
+class Widget {
+public:
+    /** Constructor doc. */
+    Widget(int id) : id_(id) {}
+private:
+    int id_;
+};

--- a/tests/fixtures/doc_comments.go
+++ b/tests/fixtures/doc_comments.go
@@ -1,0 +1,12 @@
+package main
+
+// Greet returns a greeting string.
+// It takes a name parameter.
+func Greet(name string) string {
+	return "Hello, " + name
+}
+
+// unexported has a comment too.
+func unexported() {}
+
+func noComment() {}

--- a/tests/fixtures/doc_comments.js
+++ b/tests/fixtures/doc_comments.js
@@ -1,0 +1,20 @@
+/**
+ * A documented function.
+ * @param {string} name
+ */
+function greet(name) {
+    return "Hello, " + name;
+}
+
+// Not a JSDoc comment.
+function noJsDoc() {}
+
+/**
+ * Documented class.
+ */
+class Widget {
+    /** Constructor doc. */
+    constructor(id) {
+        this.id = id;
+    }
+}

--- a/tests/fixtures/doc_comments.py
+++ b/tests/fixtures/doc_comments.py
@@ -1,0 +1,19 @@
+def documented():
+    """This function has a docstring."""
+    pass
+
+def multi_line_doc():
+    """
+    Multi-line docstring.
+    Second line.
+    """
+    pass
+
+def no_docstring():
+    pass
+
+class MyClass:
+    """Class-level docstring."""
+    def method(self):
+        """Method docstring."""
+        pass

--- a/tests/fixtures/doc_comments.rs
+++ b/tests/fixtures/doc_comments.rs
@@ -1,0 +1,21 @@
+/// This is a documented struct.
+/// It has multiple lines.
+pub struct DocStruct {
+    pub field: u32,
+}
+
+/** Block doc comment for a function. */
+pub fn block_documented() -> bool {
+    true
+}
+
+// Regular comment, not a doc comment.
+pub fn not_documented() {}
+
+/// Doc on impl method.
+impl DocStruct {
+    /// Method doc comment.
+    pub fn method(&self) -> u32 {
+        self.field
+    }
+}

--- a/tests/fixtures/doc_comments.ts
+++ b/tests/fixtures/doc_comments.ts
@@ -1,0 +1,17 @@
+/**
+ * A documented interface.
+ */
+export interface Documented {
+    name: string;
+}
+
+// Regular comment, not JSDoc.
+export function notJsDoc(): void {}
+
+/**
+ * JSDoc on a function.
+ * @param x - a number
+ */
+export function jsDocFunc(x: number): number {
+    return x;
+}

--- a/tests/go_test.rs
+++ b/tests/go_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -79,12 +81,18 @@ fn go_basic_extraction() {
     let result = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     let output = result.to_string();
     // Should contain functions
-    assert!(output.contains("NewConfig"), "should contain NewConfig function");
+    assert!(
+        output.contains("NewConfig"),
+        "should contain NewConfig function"
+    );
     assert!(output.contains("Address"), "should contain Address method");
     assert!(output.contains("helper"), "should contain helper function");
     // Should contain types
     assert!(output.contains("Config"), "should contain Config struct");
-    assert!(output.contains("Handler"), "should contain Handler interface");
+    assert!(
+        output.contains("Handler"),
+        "should contain Handler interface"
+    );
 }
 
 #[test]
@@ -95,13 +103,31 @@ fn go_pub_filter() {
     let result = process_path(f.path().to_str().unwrap(), o).unwrap();
     let output = result.to_string();
     // Exported (uppercase) should be present
-    assert!(output.contains("NewConfig"), "exported func should be present");
-    assert!(output.contains("Config"), "exported struct should be present");
-    assert!(output.contains("Handler"), "exported interface should be present");
-    assert!(output.contains("MaxRetries"), "exported const should be present");
+    assert!(
+        output.contains("NewConfig"),
+        "exported func should be present"
+    );
+    assert!(
+        output.contains("Config"),
+        "exported struct should be present"
+    );
+    assert!(
+        output.contains("Handler"),
+        "exported interface should be present"
+    );
+    assert!(
+        output.contains("MaxRetries"),
+        "exported const should be present"
+    );
     // Unexported (lowercase) should be hidden
-    assert!(!output.contains("helper"), "unexported func should be hidden");
-    assert!(!output.contains("status"), "unexported type should be hidden");
+    assert!(
+        !output.contains("helper"),
+        "unexported func should be hidden"
+    );
+    assert!(
+        !output.contains("status"),
+        "unexported type should be hidden"
+    );
 }
 
 #[test]
@@ -124,15 +150,24 @@ fn go_signatures() {
     o.signatures = true;
     let result = process_path(f.path().to_str().unwrap(), o).unwrap();
     let output = result.to_string();
-    assert!(output.contains("func NewConfig(host string, port int) *Config"), "should show function signature");
+    assert!(
+        output.contains("func NewConfig(host string, port int) *Config"),
+        "should show function signature"
+    );
 }
 
 #[test]
 fn go_fixture_file() {
     let result = process_path("tests/fixtures/sample.go", opts()).unwrap();
     let output = result.to_string();
-    assert!(output.contains("NewConfig"), "fixture should contain NewConfig");
-    assert!(output.contains("Config"), "fixture should contain Config struct");
+    assert!(
+        output.contains("NewConfig"),
+        "fixture should contain NewConfig"
+    );
+    assert!(
+        output.contains("Config"),
+        "fixture should contain Config struct"
+    );
 }
 
 #[test]

--- a/tests/handler_ts_tests.rs
+++ b/tests/handler_ts_tests.rs
@@ -1,4 +1,4 @@
-use codehud::handler::{handler_for, LanguageHandler, ItemKind, Visibility, Language, ts_language};
+use codehud::handler::{ItemKind, Language, LanguageHandler, Visibility, handler_for, ts_language};
 use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
 const TS_SOURCE: &str = r#"
@@ -164,9 +164,7 @@ fn child_symbols_returns_class_methods_and_fields() {
     let class_node = find_class_node(&tree, TS_SOURCE);
 
     let children = handler.child_symbols(class_node, TS_SOURCE);
-    let child_names: Vec<Option<&str>> = children.iter()
-        .map(|c| c.name.as_deref())
-        .collect();
+    let child_names: Vec<Option<&str>> = children.iter().map(|c| c.name.as_deref()).collect();
 
     // Methods
     assert!(child_names.contains(&Some("constructor")));
@@ -179,8 +177,14 @@ fn child_symbols_returns_class_methods_and_fields() {
     assert!(child_names.contains(&Some("name")));
     assert!(child_names.contains(&Some("nodes")));
 
-    let methods: Vec<_> = children.iter().filter(|c| c.kind == ItemKind::Method).collect();
-    let fields: Vec<_> = children.iter().filter(|c| c.kind == ItemKind::Const).collect();
+    let methods: Vec<_> = children
+        .iter()
+        .filter(|c| c.kind == ItemKind::Method)
+        .collect();
+    let fields: Vec<_> = children
+        .iter()
+        .filter(|c| c.kind == ItemKind::Const)
+        .collect();
     assert_eq!(methods.len(), 5);
     assert_eq!(fields.len(), 2);
 }
@@ -213,11 +217,23 @@ fn member_visibility_detects_private_protected() {
         let vis = handler.member_visibility(child.node, TS_SOURCE);
         match child.name.as_deref() {
             Some("name") => assert_eq!(vis, Visibility::Private, "name field should be private"),
-            Some("nodes") => assert_eq!(vis, Visibility::Protected, "nodes field should be protected"),
-            Some("constructor") => assert_eq!(vis, Visibility::Public, "constructor should be public"),
-            Some("getStartNode") => assert_eq!(vis, Visibility::Public, "getStartNode should be public"),
-            Some("__resolveNode") => assert_eq!(vis, Visibility::Private, "__ prefix should be private"),
-            Some("runWorkflow") => assert_eq!(vis, Visibility::Public, "runWorkflow should be public"),
+            Some("nodes") => assert_eq!(
+                vis,
+                Visibility::Protected,
+                "nodes field should be protected"
+            ),
+            Some("constructor") => {
+                assert_eq!(vis, Visibility::Public, "constructor should be public")
+            }
+            Some("getStartNode") => {
+                assert_eq!(vis, Visibility::Public, "getStartNode should be public")
+            }
+            Some("__resolveNode") => {
+                assert_eq!(vis, Visibility::Private, "__ prefix should be private")
+            }
+            Some("runWorkflow") => {
+                assert_eq!(vis, Visibility::Public, "runWorkflow should be public")
+            }
             Some("create") => assert_eq!(vis, Visibility::Public, "create should be public"),
             _ => {}
         }
@@ -231,14 +247,21 @@ fn signature_builds_method_signature() {
     let class_node = find_class_node(&tree, TS_SOURCE);
 
     let children = handler.child_symbols(class_node, TS_SOURCE);
-    let get_start = children.iter()
+    let get_start = children
+        .iter()
         .find(|c| c.name.as_deref() == Some("getStartNode"))
         .expect("should find getStartNode");
 
     let sig = handler.signature(get_start.node, TS_SOURCE);
-    assert!(sig.contains("getStartNode"), "signature should contain method name");
+    assert!(
+        sig.contains("getStartNode"),
+        "signature should contain method name"
+    );
     assert!(sig.contains("()"), "signature should contain params");
-    assert!(sig.contains("INode | undefined"), "signature should contain return type");
+    assert!(
+        sig.contains("INode | undefined"),
+        "signature should contain return type"
+    );
 }
 
 #[test]
@@ -248,9 +271,7 @@ fn interface_child_symbols_returns_properties() {
     let iface_node = find_interface_node(&tree, TS_SOURCE);
 
     let children = handler.child_symbols(iface_node, TS_SOURCE);
-    let names: Vec<&str> = children.iter()
-        .filter_map(|c| c.name.as_deref())
-        .collect();
+    let names: Vec<&str> = children.iter().filter_map(|c| c.name.as_deref()).collect();
 
     assert!(names.contains(&"name"));
     assert!(names.contains(&"nodes"));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 const FIXTURE_PATH: &str = "tests/fixtures/sample.rs";
 const FIXTURE_DIR: &str = "tests/fixtures";
@@ -9,9 +9,12 @@ fn test_interface_mode_basic() {
         symbols: vec![],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,21 +30,27 @@ fn test_interface_mode_basic() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain struct signature
     assert!(output.contains("pub struct User"), "Missing User struct");
     // Should contain enum
     assert!(output.contains("pub enum Role"), "Missing Role enum");
     // Should contain trait
-    assert!(output.contains("pub trait Authenticatable"), "Missing Authenticatable trait");
+    assert!(
+        output.contains("pub trait Authenticatable"),
+        "Missing Authenticatable trait"
+    );
     // Should have collapsed bodies (functions shown as { ... } in interface mode)
-    assert!(output.contains("{ ... }"), "Missing collapsed function bodies");
+    assert!(
+        output.contains("{ ... }"),
+        "Missing collapsed function bodies"
+    );
 }
 
 #[test]
@@ -50,9 +59,12 @@ fn test_expand_mode() {
         symbols: vec!["User".to_string()],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -68,13 +80,13 @@ fn test_expand_mode() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain full User struct definition
     assert!(output.contains("pub struct User"), "Missing User struct");
     assert!(output.contains("pub name: String"), "Missing name field");
@@ -88,9 +100,12 @@ fn test_expand_function() {
         symbols: vec!["public_utility".to_string()],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -106,15 +121,18 @@ fn test_expand_function() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain full function body
-    assert!(output.contains("pub fn public_utility"), "Missing function signature");
+    assert!(
+        output.contains("pub fn public_utility"),
+        "Missing function signature"
+    );
     assert!(output.contains("to_uppercase()"), "Missing function body");
 }
 
@@ -124,9 +142,12 @@ fn test_pub_filter() {
         symbols: vec![],
         pub_only: true,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -142,19 +163,25 @@ fn test_pub_filter() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain public items
     assert!(output.contains("pub struct User"), "Missing public struct");
-    
+
     // Should NOT contain private items
-    assert!(!output.contains("private_helper"), "Should not contain private_helper");
-    assert!(!output.contains("validate_email"), "Should not contain private validate_email method");
+    assert!(
+        !output.contains("private_helper"),
+        "Should not contain private_helper"
+    );
+    assert!(
+        !output.contains("validate_email"),
+        "Should not contain private validate_email method"
+    );
 }
 
 #[test]
@@ -163,9 +190,12 @@ fn test_fns_filter() {
         symbols: vec![],
         pub_only: false,
         fns_only: true,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -181,20 +211,32 @@ fn test_fns_filter() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain collapsed function bodies
-    assert!(output.contains("{ ... }"), "Missing collapsed function bodies");
-    
+    assert!(
+        output.contains("{ ... }"),
+        "Missing collapsed function bodies"
+    );
+
     // Should NOT contain struct/enum definitions
-    assert!(!output.contains("pub struct User {"), "Should not contain struct definition");
-    assert!(!output.contains("pub enum Role {"), "Should not contain enum definition");
-    assert!(!output.contains("pub trait Authenticatable {"), "Should not contain trait definition");
+    assert!(
+        !output.contains("pub struct User {"),
+        "Should not contain struct definition"
+    );
+    assert!(
+        !output.contains("pub enum Role {"),
+        "Should not contain enum definition"
+    );
+    assert!(
+        !output.contains("pub trait Authenticatable {"),
+        "Should not contain trait definition"
+    );
 }
 
 #[test]
@@ -203,9 +245,12 @@ fn test_types_filter() {
         symbols: vec![],
         pub_only: false,
         fns_only: false,
-        types_only: true, no_tests: false,
+        types_only: true,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -221,21 +266,30 @@ fn test_types_filter() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain type definitions
     assert!(output.contains("pub struct User"), "Missing User struct");
     assert!(output.contains("pub enum Role"), "Missing Role enum");
-    assert!(output.contains("pub trait Authenticatable"), "Missing Authenticatable trait");
-    assert!(output.contains("pub type UserMap"), "Missing UserMap type alias");
-    
+    assert!(
+        output.contains("pub trait Authenticatable"),
+        "Missing Authenticatable trait"
+    );
+    assert!(
+        output.contains("pub type UserMap"),
+        "Missing UserMap type alias"
+    );
+
     // Should NOT contain standalone functions
-    assert!(!output.contains("fn private_helper"), "Should not contain private_helper");
+    assert!(
+        !output.contains("fn private_helper"),
+        "Should not contain private_helper"
+    );
 }
 
 #[test]
@@ -244,9 +298,12 @@ fn test_combined_pub_fns() {
         symbols: vec![],
         pub_only: true,
         fns_only: true,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -262,23 +319,38 @@ fn test_combined_pub_fns() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should contain collapsed function bodies (public methods/functions)
-    assert!(output.contains("{ ... }"), "Missing collapsed function bodies");
-    
+    assert!(
+        output.contains("{ ... }"),
+        "Missing collapsed function bodies"
+    );
+
     // Should NOT contain private functions
-    assert!(!output.contains("private_helper"), "Should not contain private_helper");
-    assert!(!output.contains("validate_email"), "Should not contain private validate_email");
-    
+    assert!(
+        !output.contains("private_helper"),
+        "Should not contain private_helper"
+    );
+    assert!(
+        !output.contains("validate_email"),
+        "Should not contain private validate_email"
+    );
+
     // Should NOT contain type definitions
-    assert!(!output.contains("pub struct User {"), "Should not contain struct definition");
-    assert!(!output.contains("pub enum Role {"), "Should not contain enum definition");
+    assert!(
+        !output.contains("pub struct User {"),
+        "Should not contain struct definition"
+    );
+    assert!(
+        !output.contains("pub enum Role {"),
+        "Should not contain enum definition"
+    );
 }
 
 #[test]
@@ -287,9 +359,12 @@ fn test_json_output() {
         symbols: vec![],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Json, stats: false, stats_detailed: true,
+        format: OutputFormat::Json,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -305,24 +380,29 @@ fn test_json_output() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should be valid JSON
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Output should be valid JSON");
-    
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("Output should be valid JSON");
+
     // Should have files array
     assert!(parsed.get("files").is_some(), "Missing files array");
-    let files = parsed["files"].as_array().expect("files should be an array");
+    let files = parsed["files"]
+        .as_array()
+        .expect("files should be an array");
     assert!(!files.is_empty(), "files array should not be empty");
-    
+
     // First file should have items
-    assert!(files[0].get("items").is_some(), "Missing items in first file");
+    assert!(
+        files[0].get("items").is_some(),
+        "Missing items in first file"
+    );
 }
 
 #[test]
@@ -331,9 +411,12 @@ fn test_nonexistent_path() {
         symbols: vec![],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -349,11 +432,11 @@ fn test_nonexistent_path() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path("nonexistent/path/file.rs", options);
-    
+
     // Should return an error
     assert!(result.is_err(), "Should return error for nonexistent path");
 }
@@ -364,9 +447,12 @@ fn test_directory_mode() {
         symbols: vec![],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: Some(1),
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -382,16 +468,18 @@ fn test_directory_mode() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_DIR, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
-    
+
     // Should find and process sample.rs
-    assert!(output.contains("sample.rs") || output.contains("User"), 
-            "Should process sample.rs from directory");
+    assert!(
+        output.contains("sample.rs") || output.contains("User"),
+        "Should process sample.rs from directory"
+    );
 }
 
 #[test]
@@ -400,9 +488,12 @@ fn test_expand_nonexistent_symbol() {
         symbols: vec!["NonexistentSymbol".to_string()],
         pub_only: false,
         fns_only: false,
-        types_only: false, no_tests: false,
+        types_only: false,
+        no_tests: false,
         depth: None,
-        format: OutputFormat::Plain, stats: false, stats_detailed: true,
+        format: OutputFormat::Plain,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -418,16 +509,27 @@ fn test_expand_nonexistent_symbol() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
-    
+        with_comments: false,
+    };
+
     let result = process_path(FIXTURE_PATH, options);
-    
+
     // Should fail with an error for nonexistent symbol
-    assert!(result.is_err(), "process_path should fail for nonexistent symbol");
+    assert!(
+        result.is_err(),
+        "process_path should fail for nonexistent symbol"
+    );
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("not found"), "Error should mention 'not found': {}", err);
-    assert!(err.contains("NonexistentSymbol"), "Error should mention the symbol: {}", err);
+    assert!(
+        err.contains("not found"),
+        "Error should mention 'not found': {}",
+        err
+    );
+    assert!(
+        err.contains("NonexistentSymbol"),
+        "Error should mention the symbol: {}",
+        err
+    );
 }
 
 #[test]
@@ -440,7 +542,8 @@ fn test_no_tests_filter() {
         no_tests: true,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -456,8 +559,8 @@ fn test_no_tests_filter() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
+        with_comments: false,
+    };
 
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
@@ -465,11 +568,17 @@ fn test_no_tests_filter() {
 
     // Should still contain normal items
     assert!(output.contains("pub struct User"), "Missing User struct");
-    assert!(output.contains("pub fn public_utility"), "Missing public_utility");
+    assert!(
+        output.contains("pub fn public_utility"),
+        "Missing public_utility"
+    );
 
     // Should NOT contain the test module
     assert!(!output.contains("mod tests"), "Should filter out mod tests");
-    assert!(!output.contains("test_user_creation"), "Should filter out test functions");
+    assert!(
+        !output.contains("test_user_creation"),
+        "Should filter out test functions"
+    );
 }
 
 #[test]
@@ -483,7 +592,8 @@ fn test_no_tests_filter_disabled() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -499,15 +609,18 @@ fn test_no_tests_filter_disabled() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
+        with_comments: false,
+    };
 
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
 
     // Should contain the test module
-    assert!(output.contains("mod tests"), "Should include mod tests when no_tests is false");
+    assert!(
+        output.contains("mod tests"),
+        "Should include mod tests when no_tests is false"
+    );
 }
 
 #[test]
@@ -520,7 +633,8 @@ fn test_stats_output_plain() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: true, stats_detailed: true,
+        stats: true,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -536,16 +650,22 @@ fn test_stats_output_plain() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
+        with_comments: false,
+    };
 
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
 
     // Stats output should contain file count, line/byte info, and token estimate
-    assert!(output.contains("Files:") && output.contains("Lines:") && output.contains("Bytes:") && output.contains("Tokens:"),
-            "Stats should contain summary counts including tokens. Got: {}", output);
+    assert!(
+        output.contains("Files:")
+            && output.contains("Lines:")
+            && output.contains("Bytes:")
+            && output.contains("Tokens:"),
+        "Stats should contain summary counts including tokens. Got: {}",
+        output
+    );
 }
 
 #[test]
@@ -558,7 +678,8 @@ fn test_stats_output_json() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Json,
-        stats: true, stats_detailed: true,
+        stats: true,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -574,20 +695,22 @@ fn test_stats_output_json() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
+        with_comments: false,
+    };
 
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
 
     // Should be valid JSON
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Stats JSON output should be valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("Stats JSON output should be valid JSON");
 
     // Should have some structure with file info
-    assert!(parsed.is_object() || parsed.is_array(),
-            "Stats JSON should be an object or array");
+    assert!(
+        parsed.is_object() || parsed.is_array(),
+        "Stats JSON should be an object or array"
+    );
 }
 
 #[test]
@@ -600,7 +723,8 @@ fn test_stats_with_directory() {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: true, stats_detailed: true,
+        stats: true,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -616,15 +740,18 @@ fn test_stats_with_directory() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
-    
-};
+        with_comments: false,
+    };
 
     let result = process_path(FIXTURE_DIR, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
 
     // Directory stats should show totals for multiple files
-    assert!(!output.is_empty(), "Stats for directory should not be empty");
+    assert!(
+        !output.is_empty(),
+        "Stats for directory should not be empty"
+    );
 }
 
 #[test]
@@ -654,6 +781,7 @@ fn test_stats_summary_only_plain() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -661,9 +789,16 @@ fn test_stats_summary_only_plain() {
     let output = result.unwrap();
 
     // Should have the summary line
-    assert!(output.contains("Files:"), "Should contain summary. Got: {}", output);
+    assert!(
+        output.contains("Files:"),
+        "Should contain summary. Got: {}",
+        output
+    );
     // Should NOT have per-file breakdown (lines with " — ")
-    assert!(!output.contains(" — "), "summary-only should skip per-file lines");
+    assert!(
+        !output.contains(" — "),
+        "summary-only should skip per-file lines"
+    );
 }
 
 #[test]
@@ -693,17 +828,20 @@ fn test_stats_summary_only_json() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
     assert!(result.is_ok(), "process_path failed: {:?}", result.err());
     let output = result.unwrap();
 
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Should be valid JSON");
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("Should be valid JSON");
     // per_file should be empty
     let per_file = parsed.get("per_file").expect("should have per_file key");
-    assert!(per_file.as_array().unwrap().is_empty(), "summary-only JSON should have empty per_file");
+    assert!(
+        per_file.as_array().unwrap().is_empty(),
+        "summary-only JSON should have empty per_file"
+    );
     // but files count should be > 0
     let files = parsed.get("files").unwrap().as_u64().unwrap();
     assert!(files > 0, "should still report file count");
@@ -736,6 +874,7 @@ fn test_stats_summary_shows_languages() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -743,9 +882,16 @@ fn test_stats_summary_shows_languages() {
     let output = result.unwrap();
 
     // Summary should include Languages line
-    assert!(output.contains("Languages:"), "Summary should show language breakdown. Got: {}", output);
+    assert!(
+        output.contains("Languages:"),
+        "Summary should show language breakdown. Got: {}",
+        output
+    );
     // Should NOT show per-file details
-    assert!(!output.contains(" — "), "Summary mode should not list individual files");
+    assert!(
+        !output.contains(" — "),
+        "Summary mode should not list individual files"
+    );
 }
 
 #[test]
@@ -775,6 +921,7 @@ fn test_stats_detailed_shows_per_file() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -782,7 +929,11 @@ fn test_stats_detailed_shows_per_file() {
     let output = result.unwrap();
 
     // Detailed mode SHOULD show per-file breakdown
-    assert!(output.contains(" — "), "Detailed mode should list individual files. Got: {}", output);
+    assert!(
+        output.contains(" — "),
+        "Detailed mode should list individual files. Got: {}",
+        output
+    );
 }
 
 #[test]
@@ -812,6 +963,7 @@ fn test_stats_summary_shows_dirs() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     };
 
     let result = process_path(FIXTURE_DIR, options);
@@ -819,5 +971,9 @@ fn test_stats_summary_shows_dirs() {
     let output = result.unwrap();
 
     // Summary should include Dirs count
-    assert!(output.contains("Dirs:"), "Summary should show directory count. Got: {}", output);
+    assert!(
+        output.contains("Dirs:"),
+        "Summary should show directory count. Got: {}",
+        output
+    );
 }

--- a/tests/java_test.rs
+++ b/tests/java_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -112,7 +114,10 @@ fn java_expand_class() {
 
     assert!(output.contains("class UserService"), "Missing class");
     assert!(output.contains("getUser"), "Missing getUser method");
-    assert!(output.contains("refreshCache"), "Missing refreshCache method");
+    assert!(
+        output.contains("refreshCache"),
+        "Missing refreshCache method"
+    );
     assert!(output.contains("create"), "Missing static method");
     assert!(output.contains("MAX_USERS"), "Missing field");
 }
@@ -147,8 +152,10 @@ public class Foo {
 
     // In fns mode, standalone methods should appear but not classes
     // Note: Java methods are always inside classes, so this tests top-level behavior
-    assert!(!output.contains("class Foo") || output.contains("bar"),
-            "fns filter behavior check");
+    assert!(
+        !output.contains("class Foo") || output.contains("bar"),
+        "fns filter behavior check"
+    );
 }
 
 // --- Types filter ---
@@ -160,8 +167,14 @@ fn java_types_filter() {
     o.types_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("class UserService"), "Missing class as type");
-    assert!(output.contains("interface Repository"), "Missing interface as type");
+    assert!(
+        output.contains("class UserService"),
+        "Missing class as type"
+    );
+    assert!(
+        output.contains("interface Repository"),
+        "Missing interface as type"
+    );
     assert!(output.contains("enum Status"), "Missing enum as type");
 }
 
@@ -242,7 +255,10 @@ class InternalHelper {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("class UserService"), "Missing public class");
-    assert!(!output.contains("InternalHelper"), "Package-private class should be hidden");
+    assert!(
+        !output.contains("InternalHelper"),
+        "Package-private class should be hidden"
+    );
 }
 
 // --- Annotations ---
@@ -268,6 +284,12 @@ fn java_imports() {
     let f = write_java(SAMPLE_JAVA);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("import java.util.List"), "Missing List import");
-    assert!(output.contains("import java.util.Map"), "Missing Map import");
+    assert!(
+        output.contains("import java.util.List"),
+        "Missing List import"
+    );
+    assert!(
+        output.contains("import java.util.Map"),
+        "Missing Map import"
+    );
 }

--- a/tests/javascript_test.rs
+++ b/tests/javascript_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,8 +28,8 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
-
 }
 
 fn write_js(content: &str) -> NamedTempFile {
@@ -101,7 +102,10 @@ fn javascript_interface_mode_basic() {
     assert!(output.contains("MAX_USERS"), "Missing const MAX_USERS");
     assert!(output.contains("currentUser"), "Missing let currentUser");
     assert!(output.contains("legacyFlag"), "Missing var legacyFlag");
-    assert!(output.contains("function helperFunction"), "Missing helperFunction");
+    assert!(
+        output.contains("function helperFunction"),
+        "Missing helperFunction"
+    );
     assert!(output.contains("arrowFn"), "Missing arrowFn const");
     assert!(output.contains("mutableVal"), "Missing mutableVal");
     assert!(output.contains("{ ... }"), "Missing collapsed bodies");
@@ -117,7 +121,10 @@ fn javascript_expand_symbol() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("function publicApi"), "Missing publicApi");
-    assert!(output.contains("trim().toLowerCase()"), "Missing function body");
+    assert!(
+        output.contains("trim().toLowerCase()"),
+        "Missing function body"
+    );
 }
 
 #[test]
@@ -128,7 +135,10 @@ fn javascript_expand_class() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("class UserService"), "Missing class");
-    assert!(output.contains("new Map()") || output.contains("this.db"), "Missing class body");
+    assert!(
+        output.contains("new Map()") || output.contains("this.db"),
+        "Missing class body"
+    );
 }
 
 // --- Class methods ---
@@ -165,8 +175,14 @@ fn javascript_async_static_methods() {
     o.symbols = vec!["Service".to_string()];
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("async"), "Missing async keyword in method signature");
-    assert!(output.contains("static"), "Missing static keyword in method signature");
+    assert!(
+        output.contains("async"),
+        "Missing async keyword in method signature"
+    );
+    assert!(
+        output.contains("static"),
+        "Missing static keyword in method signature"
+    );
 }
 
 // --- Export variants ---
@@ -178,7 +194,10 @@ fn javascript_export_variants() {
     o.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("function publicApi"), "Missing export function");
+    assert!(
+        output.contains("function publicApi"),
+        "Missing export function"
+    );
     assert!(output.contains("class UserService"), "Missing export class");
     assert!(output.contains("MAX_USERS"), "Missing export const");
     assert!(output.contains("currentUser"), "Missing export let");
@@ -202,9 +221,18 @@ fn javascript_variable_declarations() {
     let f = write_js(SAMPLE_JS);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("const") && output.contains("MAX_USERS"), "Missing const declaration");
-    assert!(output.contains("let") && output.contains("currentUser"), "Missing let declaration");
-    assert!(output.contains("var") && output.contains("legacyFlag"), "Missing var declaration");
+    assert!(
+        output.contains("const") && output.contains("MAX_USERS"),
+        "Missing const declaration"
+    );
+    assert!(
+        output.contains("let") && output.contains("currentUser"),
+        "Missing let declaration"
+    );
+    assert!(
+        output.contains("var") && output.contains("legacyFlag"),
+        "Missing var declaration"
+    );
 }
 
 // --- Arrow functions in const ---
@@ -237,7 +265,10 @@ export class Counter extends React.Component {
     let f = write_jsx(src);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("function Greeting"), "Missing function in JSX");
+    assert!(
+        output.contains("function Greeting"),
+        "Missing function in JSX"
+    );
     assert!(output.contains("class Counter"), "Missing class in JSX");
     assert!(output.contains("import"), "Missing import in JSX");
 }
@@ -251,10 +282,22 @@ fn javascript_pub_filter() {
     o.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("function publicApi"), "Missing exported function");
-    assert!(output.contains("class UserService"), "Missing exported class");
-    assert!(!output.contains("helperFunction"), "Should not contain non-exported fn");
-    assert!(!output.contains("legacyFlag"), "Should not contain non-exported var");
+    assert!(
+        output.contains("function publicApi"),
+        "Missing exported function"
+    );
+    assert!(
+        output.contains("class UserService"),
+        "Missing exported class"
+    );
+    assert!(
+        !output.contains("helperFunction"),
+        "Should not contain non-exported fn"
+    );
+    assert!(
+        !output.contains("legacyFlag"),
+        "Should not contain non-exported var"
+    );
 }
 
 #[test]
@@ -264,9 +307,14 @@ fn javascript_fns_filter() {
     o.fns_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("function publicApi") || output.contains("function helperFunction"),
-            "Missing functions");
-    assert!(!output.contains("class UserService"), "Should not contain class");
+    assert!(
+        output.contains("function publicApi") || output.contains("function helperFunction"),
+        "Missing functions"
+    );
+    assert!(
+        !output.contains("class UserService"),
+        "Should not contain class"
+    );
     assert!(!output.contains("MAX_USERS"), "Should not contain const");
 }
 
@@ -277,8 +325,14 @@ fn javascript_types_filter() {
     o.types_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("class UserService"), "Missing class as type");
-    assert!(!output.contains("function helperFunction"), "Should not contain standalone fn");
+    assert!(
+        output.contains("class UserService"),
+        "Missing class as type"
+    );
+    assert!(
+        !output.contains("function helperFunction"),
+        "Should not contain standalone fn"
+    );
 }
 
 #[test]
@@ -289,9 +343,18 @@ fn javascript_pub_fns_combined() {
     o.fns_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("function publicApi"), "Missing exported function");
-    assert!(!output.contains("helperFunction"), "Should not contain non-exported fn");
-    assert!(!output.contains("class UserService"), "Should not contain class with fns filter");
+    assert!(
+        output.contains("function publicApi"),
+        "Missing exported function"
+    );
+    assert!(
+        !output.contains("helperFunction"),
+        "Should not contain non-exported fn"
+    );
+    assert!(
+        !output.contains("class UserService"),
+        "Should not contain class with fns filter"
+    );
 }
 
 // --- Stats ---
@@ -303,7 +366,11 @@ fn javascript_stats_mode() {
     o.stats = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("Files:"), "Missing files count. Got: {}", output);
+    assert!(
+        output.contains("Files:"),
+        "Missing files count. Got: {}",
+        output
+    );
     assert!(output.contains("Lines:"), "Missing lines count");
     assert!(output.contains("Bytes:"), "Missing bytes count");
 }
@@ -312,35 +379,59 @@ fn javascript_stats_mode() {
 
 #[test]
 fn javascript_pub_filter_hides_hash_private() {
-    let f = write_js(r#"
+    let f = write_js(
+        r#"
 export class Foo {
     greet() {}
     #secret() { return 42; }
 }
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        fns_only: true,
-        ..opts()
-    }).unwrap();
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            fns_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
     assert!(out.contains("greet"), "public method should be visible");
     assert!(!out.contains("secret"), "#private method should be hidden");
 }
 
 #[test]
 fn javascript_pub_filter_non_exported_hidden() {
-    let f = write_js(r#"
+    let f = write_js(
+        r#"
 export function publicFn() {}
 function privateFn() {}
 export class PublicClass {}
 class PrivateClass {}
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        ..opts()
-    }).unwrap();
-    assert!(out.contains("publicFn"), "exported function should be visible");
-    assert!(out.contains("PublicClass"), "exported class should be visible");
-    assert!(!out.contains("privateFn"), "non-exported function should be hidden");
-    assert!(!out.contains("PrivateClass"), "non-exported class should be hidden");
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
+    assert!(
+        out.contains("publicFn"),
+        "exported function should be visible"
+    );
+    assert!(
+        out.contains("PublicClass"),
+        "exported class should be visible"
+    );
+    assert!(
+        !out.contains("privateFn"),
+        "non-exported function should be hidden"
+    );
+    assert!(
+        !out.contains("PrivateClass"),
+        "non-exported class should be hidden"
+    );
 }

--- a/tests/json_test.rs
+++ b/tests/json_test.rs
@@ -1,5 +1,5 @@
-use codehud::editor::{self, EditResult};
 use codehud::Language;
+use codehud::editor::{self, EditResult};
 
 #[test]
 fn test_symbol_line_range_simple() {

--- a/tests/kotlin_test.rs
+++ b/tests/kotlin_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -115,12 +117,21 @@ fn kotlin_interface_mode_basic() {
     assert!(output.contains("import"), "Missing import");
     assert!(output.contains("interface Repository"), "Missing interface");
     assert!(output.contains("data class User"), "Missing data class");
-    assert!(output.contains("sealed class Result"), "Missing sealed class");
+    assert!(
+        output.contains("sealed class Result"),
+        "Missing sealed class"
+    );
     assert!(output.contains("enum class Status"), "Missing enum class");
     assert!(output.contains("object AppConfig"), "Missing object");
     assert!(output.contains("class UserService"), "Missing class");
-    assert!(output.contains("topLevelFunction"), "Missing top-level function");
-    assert!(output.contains("topLevelProperty"), "Missing top-level property");
+    assert!(
+        output.contains("topLevelFunction"),
+        "Missing top-level function"
+    );
+    assert!(
+        output.contains("topLevelProperty"),
+        "Missing top-level property"
+    );
     assert!(output.contains("typealias"), "Missing type alias");
 }
 
@@ -135,8 +146,14 @@ fn kotlin_expand_class() {
 
     assert!(output.contains("class UserService"), "Missing class");
     assert!(output.contains("getUser"), "Missing getUser method");
-    assert!(output.contains("refreshCache"), "Missing refreshCache method");
-    assert!(output.contains("companion object"), "Missing companion object");
+    assert!(
+        output.contains("refreshCache"),
+        "Missing refreshCache method"
+    );
+    assert!(
+        output.contains("companion object"),
+        "Missing companion object"
+    );
     assert!(output.contains("cache"), "Missing property");
 }
 
@@ -200,8 +217,14 @@ private class PrivateClass {
     o.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("class MyClass"), "Missing public class (Kotlin default is public)");
-    assert!(!output.contains("PrivateClass"), "Private class should be hidden");
+    assert!(
+        output.contains("class MyClass"),
+        "Missing public class (Kotlin default is public)"
+    );
+    assert!(
+        !output.contains("PrivateClass"),
+        "Private class should be hidden"
+    );
 }
 
 // --- Types filter ---
@@ -227,7 +250,10 @@ fn kotlin_fns_filter() {
     o.fns_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("topLevelFunction"), "Missing top-level function");
+    assert!(
+        output.contains("topLevelFunction"),
+        "Missing top-level function"
+    );
 }
 
 // --- Stats ---
@@ -250,8 +276,14 @@ fn kotlin_imports() {
     let f = write_kotlin(SAMPLE_KOTLIN);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("import kotlin.collections.List"), "Missing List import");
-    assert!(output.contains("import kotlin.collections.Map"), "Missing Map import");
+    assert!(
+        output.contains("import kotlin.collections.List"),
+        "Missing List import"
+    );
+    assert!(
+        output.contains("import kotlin.collections.Map"),
+        "Missing Map import"
+    );
 }
 
 // --- List symbols ---
@@ -269,8 +301,14 @@ fn kotlin_list_symbols() {
     assert!(output.contains("Status"), "Missing enum in list");
     assert!(output.contains("AppConfig"), "Missing object in list");
     assert!(output.contains("UserService"), "Missing class in list");
-    assert!(output.contains("topLevelFunction"), "Missing function in list");
-    assert!(output.contains("topLevelProperty"), "Missing property in list");
+    assert!(
+        output.contains("topLevelFunction"),
+        "Missing function in list"
+    );
+    assert!(
+        output.contains("topLevelProperty"),
+        "Missing property in list"
+    );
     assert!(output.contains("StringList"), "Missing typealias in list");
 }
 
@@ -302,8 +340,20 @@ class DefaultPublicClass
     o.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("PublicClass"), "Missing explicit public class");
-    assert!(output.contains("DefaultPublicClass"), "Missing default-public class");
-    assert!(!output.contains("PrivateClass"), "Private class should be hidden");
-    assert!(!output.contains("InternalClass"), "Internal class should be hidden with pub filter");
+    assert!(
+        output.contains("PublicClass"),
+        "Missing explicit public class"
+    );
+    assert!(
+        output.contains("DefaultPublicClass"),
+        "Missing default-public class"
+    );
+    assert!(
+        !output.contains("PrivateClass"),
+        "Private class should be hidden"
+    );
+    assert!(
+        !output.contains("InternalClass"),
+        "Internal class should be hidden with pub filter"
+    );
 }

--- a/tests/lines_test.rs
+++ b/tests/lines_test.rs
@@ -10,7 +10,11 @@ fn write_file(dir: &TempDir, name: &str, content: &str) -> String {
 #[test]
 fn lines_basic_extraction() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", "fn foo() {\n    let x = 1;\n    let y = 2;\n    x + y\n}\n");
+    let path = write_file(
+        &dir,
+        "test.rs",
+        "fn foo() {\n    let x = 1;\n    let y = 2;\n    x + y\n}\n",
+    );
     let result = codehud::extract_lines(&path, "2-4", false).unwrap();
     assert!(result.contains("// Inside: foo"));
     assert!(result.contains("L2:"));
@@ -46,7 +50,12 @@ fn lines_out_of_range_start() {
     let path = write_file(&dir, "test.rs", "fn foo() {}\n");
     let result = codehud::extract_lines(&path, "100-200", false);
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("beyond end of file"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("beyond end of file")
+    );
 }
 
 #[test]
@@ -79,7 +88,11 @@ fn lines_directory_errors() {
 #[test]
 fn lines_nested_context_typescript() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.ts", "class MyClass {\n    run() {\n        console.log('hello');\n    }\n}\n");
+    let path = write_file(
+        &dir,
+        "test.ts",
+        "class MyClass {\n    run() {\n        console.log('hello');\n    }\n}\n",
+    );
     let result = codehud::extract_lines(&path, "3-3", false).unwrap();
     assert!(result.contains("// Inside:"));
     assert!(result.contains("MyClass"));

--- a/tests/list_symbols_test.rs
+++ b/tests/list_symbols_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::process::Command;
 
 const FIXTURE_PATH: &str = "tests/fixtures/sample.rs";
@@ -10,7 +10,11 @@ fn run_codehud(args: &[&str]) -> String {
         .args(args)
         .output()
         .expect("failed to run codehud");
-    assert!(output.status.success(), "codehud failed: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "codehud failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     String::from_utf8(output.stdout).unwrap()
 }
 
@@ -23,7 +27,8 @@ fn default_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -39,6 +44,7 @@ fn default_options() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -83,6 +89,7 @@ fn test_list_symbols_smaller_than_interface() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let interface_output = process_path(FIXTURE_PATH, interface_opts).unwrap();
@@ -121,7 +128,9 @@ fn test_list_symbols_with_fns_filter() {
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Should only contain fn symbols
     for line in output.lines().skip(1) {
-        if line.trim().is_empty() { continue; }
+        if line.trim().is_empty() {
+            continue;
+        }
         assert!(line.contains("fn "), "Expected fn in: {}", line);
     }
 }
@@ -135,9 +144,13 @@ fn test_list_symbols_with_types_filter() {
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Should only contain type symbols (struct/enum/trait/type)
     for line in output.lines().skip(1) {
-        if line.trim().is_empty() { continue; }
-        let has_type = line.contains("struct ") || line.contains("enum ") 
-            || line.contains("trait ") || line.contains("type ")
+        if line.trim().is_empty() {
+            continue;
+        }
+        let has_type = line.contains("struct ")
+            || line.contains("enum ")
+            || line.contains("trait ")
+            || line.contains("type ")
             || line.contains("class ");
         assert!(has_type, "Expected type symbol in: {}", line);
     }
@@ -181,12 +194,16 @@ fn test_list_symbols_no_imports_excludes_use() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Should not contain any "use" entries
-    assert!(!output.lines().any(|l| l.trim_start().starts_with("use ")),
-        "Expected no 'use' entries with --no-imports, got:\n{}", output);
+    assert!(
+        !output.lines().any(|l| l.trim_start().starts_with("use ")),
+        "Expected no 'use' entries with --no-imports, got:\n{}",
+        output
+    );
     // Should still contain other symbols
     assert!(output.contains("struct") && output.contains("User"));
     assert!(output.contains("enum") && output.contains("Role"));
@@ -206,12 +223,16 @@ fn test_list_symbols_without_no_imports_includes_use() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Should contain "use" entries
-    assert!(output.lines().any(|l| l.trim_start().starts_with("use ")),
-        "Expected 'use' entries without --no-imports, got:\n{}", output);
+    assert!(
+        output.lines().any(|l| l.trim_start().starts_with("use ")),
+        "Expected 'use' entries without --no-imports, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -222,15 +243,17 @@ fn test_list_symbols_json_format() {
     };
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Must be valid JSON
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("--json --list-symbols should produce valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("--json --list-symbols should produce valid JSON");
     // Should be an array of file entries
     let arr = parsed.as_array().expect("Expected JSON array");
     assert!(!arr.is_empty(), "Expected at least one file entry");
     // Each entry should have path and symbols
     let first = &arr[0];
     assert!(first.get("path").is_some(), "Expected 'path' field");
-    let symbols = first.get("symbols").and_then(|s| s.as_array())
+    let symbols = first
+        .get("symbols")
+        .and_then(|s| s.as_array())
         .expect("Expected 'symbols' array");
     assert!(!symbols.is_empty(), "Expected at least one symbol");
     // Each symbol should have kind, name, line
@@ -239,7 +262,10 @@ fn test_list_symbols_json_format() {
     assert!(sym.get("name").is_some(), "Expected 'name' field");
     assert!(sym.get("line").is_some(), "Expected 'line' field");
     assert!(sym.get("line_end").is_some(), "Expected 'line_end' field");
-    assert!(sym.get("visibility").is_some(), "Expected 'visibility' field");
+    assert!(
+        sym.get("visibility").is_some(),
+        "Expected 'visibility' field"
+    );
 }
 
 #[test]
@@ -252,11 +278,15 @@ fn test_list_symbols_json_contains_expected_symbols() {
     let output = process_path(FIXTURE_PATH, options).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     let symbols = parsed[0]["symbols"].as_array().unwrap();
-    let names: Vec<&str> = symbols.iter()
-        .filter_map(|s| s["name"].as_str())
-        .collect();
-    assert!(names.contains(&"User"), "Expected User struct in JSON symbols");
-    assert!(names.contains(&"Role"), "Expected Role enum in JSON symbols");
+    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert!(
+        names.contains(&"User"),
+        "Expected User struct in JSON symbols"
+    );
+    assert!(
+        names.contains(&"Role"),
+        "Expected Role enum in JSON symbols"
+    );
 }
 
 #[test]
@@ -270,7 +300,10 @@ fn test_list_symbols_json_directory() {
     let parsed: serde_json::Value = serde_json::from_str(&output)
         .expect("--json --list-symbols on directory should produce valid JSON");
     let arr = parsed.as_array().unwrap();
-    assert!(arr.len() >= 1, "Expected multiple file entries for directory");
+    assert!(
+        arr.len() >= 1,
+        "Expected multiple file entries for directory"
+    );
 }
 
 #[test]
@@ -287,12 +320,16 @@ fn test_list_symbols_no_imports_typescript() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/imports_sample.ts", options).unwrap();
     // Should not contain any "use" entries (TS imports map to ItemKind::Use)
-    assert!(!output.lines().any(|l| l.trim_start().starts_with("use ")),
-        "Expected no import entries with --no-imports, got:\n{}", output);
+    assert!(
+        !output.lines().any(|l| l.trim_start().starts_with("use ")),
+        "Expected no import entries with --no-imports, got:\n{}",
+        output
+    );
     // Should still contain the actual symbols
     assert!(output.contains("UserService"));
     assert!(output.contains("UserController"));
@@ -303,8 +340,11 @@ fn test_list_symbols_no_imports_typescript() {
 fn test_list_symbols_empty_vue_script_shows_header() {
     let output = process_path("tests/fixtures/empty_script.vue", default_options()).unwrap();
     // File header should appear even when script block is empty
-    assert!(output.contains("empty_script.vue"),
-        "Expected file header for empty Vue script, got:\n{}", output);
+    assert!(
+        output.contains("empty_script.vue"),
+        "Expected file header for empty Vue script, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -319,15 +359,32 @@ fn test_list_symbols_vue_sfc_depth_2_shows_class_members() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
     // Should show class methods at depth 2
-    assert!(output.contains("increment"), "Expected 'increment' method at depth 2, got:\n{}", output);
-    assert!(output.contains("decrement"), "Expected 'decrement' method at depth 2, got:\n{}", output);
+    assert!(
+        output.contains("increment"),
+        "Expected 'increment' method at depth 2, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("decrement"),
+        "Expected 'decrement' method at depth 2, got:\n{}",
+        output
+    );
     // Should use TypeScript display names, not Rust fallback
-    assert!(output.contains("interface"), "Expected 'interface' (not 'trait') for Vue SFC, got:\n{}", output);
-    assert!(!output.contains("trait"), "Should not use Rust 'trait' display name for Vue SFC, got:\n{}", output);
+    assert!(
+        output.contains("interface"),
+        "Expected 'interface' (not 'trait') for Vue SFC, got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("trait"),
+        "Should not use Rust 'trait' display name for Vue SFC, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -342,14 +399,22 @@ fn test_list_symbols_vue_sfc_depth_1_hides_class_members() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/component.vue", options).unwrap();
     // Class should appear but methods should not at depth 1
-    assert!(output.contains("Counter"), "Expected 'Counter' class at depth 1");
+    assert!(
+        output.contains("Counter"),
+        "Expected 'Counter' class at depth 1"
+    );
     // Methods should be hidden at depth 1
     let lines: Vec<&str> = output.lines().filter(|l| l.contains("increment")).collect();
-    assert!(lines.is_empty(), "Methods should be hidden at depth 1, got:\n{}", output);
+    assert!(
+        lines.is_empty(),
+        "Methods should be hidden at depth 1, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -360,8 +425,11 @@ fn test_list_symbols_kind_column_alignment() {
         if line.starts_with("  ") {
             // After "  " there should be a 10-char kind field
             let after_indent = &line[2..];
-            assert!(after_indent.len() >= 10,
-                "Line too short for padded kind: {}", line);
+            assert!(
+                after_indent.len() >= 10,
+                "Line too short for padded kind: {}",
+                line
+            );
             // The 10th character should be a space (padding)
             // because even "type alias" (10 chars) gets followed by a space from the format
         }
@@ -380,12 +448,17 @@ fn test_list_symbols_depth_2_shows_class_members() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         ..default_options()
     };
     let output = process_path("tests/fixtures/sample.ts", options).unwrap();
     // Should show methods indented under classes
     // At depth 2, Method items should appear
-    assert!(output.contains("fn"), "Expected method entries with symbol-depth 2, got:\n{}", output);
+    assert!(
+        output.contains("fn"),
+        "Expected method entries with symbol-depth 2, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -400,6 +473,7 @@ fn test_list_symbols_depth_2_json_includes_methods() {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         format: OutputFormat::Json,
         ..default_options()
     };
@@ -407,7 +481,11 @@ fn test_list_symbols_depth_2_json_includes_methods() {
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     let symbols = parsed[0]["symbols"].as_array().unwrap();
     let kinds: Vec<&str> = symbols.iter().filter_map(|s| s["kind"].as_str()).collect();
-    assert!(kinds.contains(&"fn"), "Expected 'fn' kind for methods in depth-2 JSON, got: {:?}", kinds);
+    assert!(
+        kinds.contains(&"fn"),
+        "Expected 'fn' kind for methods in depth-2 JSON, got: {:?}",
+        kinds
+    );
 }
 
 // ============================================================
@@ -417,8 +495,8 @@ fn test_list_symbols_depth_2_json_includes_methods() {
 #[test]
 fn test_cli_json_list_symbols_single_file() {
     let output = run_codehud(&["--json", "--list-symbols", FIXTURE_PATH]);
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("CLI --json --list-symbols should output valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("CLI --json --list-symbols should output valid JSON");
     let arr = parsed.as_array().expect("Expected JSON array");
     assert!(!arr.is_empty(), "Expected at least one file entry");
     assert!(arr[0].get("path").is_some(), "Expected 'path' field");
@@ -431,7 +509,10 @@ fn test_cli_json_list_symbols_directory() {
     let parsed: serde_json::Value = serde_json::from_str(&output)
         .expect("CLI --json --list-symbols on directory should output valid JSON");
     let arr = parsed.as_array().expect("Expected JSON array");
-    assert!(arr.len() > 1, "Expected multiple file entries for directory");
+    assert!(
+        arr.len() > 1,
+        "Expected multiple file entries for directory"
+    );
 }
 
 #[test]
@@ -462,7 +543,11 @@ fn test_cli_json_list_symbols_with_no_imports() {
     if !arr.is_empty() {
         let symbols = arr[0]["symbols"].as_array().unwrap();
         for sym in symbols {
-            assert_ne!(sym["kind"].as_str().unwrap(), "use", "Should not contain 'use' with --no-imports");
+            assert_ne!(
+                sym["kind"].as_str().unwrap(),
+                "use",
+                "Should not contain 'use' with --no-imports"
+            );
         }
     }
 }
@@ -476,15 +561,24 @@ fn test_cli_json_list_symbols_with_pub() {
     if !arr.is_empty() {
         let symbols = arr[0]["symbols"].as_array().unwrap();
         for sym in symbols {
-            assert_eq!(sym["visibility"].as_str().unwrap(), "public",
-                "All symbols should be public with --pub flag");
+            assert_eq!(
+                sym["visibility"].as_str().unwrap(),
+                "public",
+                "All symbols should be public with --pub flag"
+            );
         }
     }
 }
 
 #[test]
 fn test_cli_json_list_symbols_with_symbol_depth() {
-    let output = run_codehud(&["--json", "--list-symbols", "--symbol-depth", "2", "tests/fixtures/sample.ts"]);
+    let output = run_codehud(&[
+        "--json",
+        "--list-symbols",
+        "--symbol-depth",
+        "2",
+        "tests/fixtures/sample.ts",
+    ]);
     let parsed: serde_json::Value = serde_json::from_str(&output)
         .expect("CLI --json --list-symbols --symbol-depth 2 should output valid JSON");
     let arr = parsed.as_array().unwrap();
@@ -496,14 +590,19 @@ fn test_cli_json_list_symbols_not_plain_text() {
     // Explicitly verify that --json flag changes the output format
     let plain_output = run_codehud(&["--list-symbols", FIXTURE_PATH]);
     let json_output = run_codehud(&["--json", "--list-symbols", FIXTURE_PATH]);
-    
+
     // Plain output should NOT be valid JSON
-    assert!(serde_json::from_str::<serde_json::Value>(&plain_output).is_err(),
-        "Plain --list-symbols should NOT be valid JSON");
-    
-    // JSON output MUST be valid JSON  
-    assert!(serde_json::from_str::<serde_json::Value>(&json_output).is_ok(),
-        "--json --list-symbols MUST be valid JSON, got:\n{}", &json_output[..json_output.len().min(200)]);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&plain_output).is_err(),
+        "Plain --list-symbols should NOT be valid JSON"
+    );
+
+    // JSON output MUST be valid JSON
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&json_output).is_ok(),
+        "--json --list-symbols MUST be valid JSON, got:\n{}",
+        &json_output[..json_output.len().min(200)]
+    );
 }
 
 #[test]
@@ -513,9 +612,21 @@ fn test_minimal_outputs_bare_names() {
     let output = process_path(FIXTURE_PATH, options).unwrap();
     // Each line should be a bare name with no type/location info
     for line in output.lines() {
-        assert!(!line.contains("L"), "minimal mode should not contain line numbers: {}", line);
-        assert!(!line.contains("fn "), "minimal mode should not contain kind labels: {}", line);
-        assert!(!line.contains("struct "), "minimal mode should not contain kind labels: {}", line);
+        assert!(
+            !line.contains("L"),
+            "minimal mode should not contain line numbers: {}",
+            line
+        );
+        assert!(
+            !line.contains("fn "),
+            "minimal mode should not contain kind labels: {}",
+            line
+        );
+        assert!(
+            !line.contains("struct "),
+            "minimal mode should not contain kind labels: {}",
+            line
+        );
     }
     // Should contain known symbols from sample.rs
     let names: Vec<&str> = output.lines().collect();
@@ -529,19 +640,27 @@ fn test_cli_minimal_flag() {
     assert!(!lines.is_empty());
     // No line should contain whitespace-padded columns or line numbers
     for line in &lines {
-        assert!(!line.contains("  "), "minimal output should not have padded columns: {}", line);
+        assert!(
+            !line.contains("  "),
+            "minimal output should not have padded columns: {}",
+            line
+        );
     }
 }
 
 #[test]
 fn test_cli_minimal_json() {
     let output = run_codehud(&["--list-symbols", "--minimal", "--json", FIXTURE_PATH]);
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("--minimal --json should output valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("--minimal --json should output valid JSON");
     let arr = parsed.as_array().expect("should be an array of names");
     assert!(!arr.is_empty());
     // All entries should be strings (bare names)
     for entry in arr {
-        assert!(entry.is_string(), "each entry should be a string, got: {}", entry);
+        assert!(
+            entry.is_string(),
+            "each entry should be a string, got: {}",
+            entry
+        );
     }
 }

--- a/tests/max_lines_test.rs
+++ b/tests/max_lines_test.rs
@@ -62,12 +62,23 @@ fn max_lines_truncates_long_function() {
     let dir = TempDir::new().unwrap();
     let path = write_ts_file(&dir, "test.ts", LONG_FUNCTION);
     let output = run_codehud(&[&path, "processData", "--max-lines", "3"]);
-    assert!(output.contains("[truncated:"), "expected truncation indicator, got:\n{}", output);
+    assert!(
+        output.contains("[truncated:"),
+        "expected truncation indicator, got:\n{}",
+        output
+    );
     // Should show exactly 3 lines of content before truncation
     let lines: Vec<&str> = output.lines().collect();
-    let trunc_line = lines.iter().position(|l| l.contains("[truncated:")).unwrap();
+    let trunc_line = lines
+        .iter()
+        .position(|l| l.contains("[truncated:"))
+        .unwrap();
     // Header is line 0, then 3 content lines, then truncation
-    assert_eq!(trunc_line, 4, "truncation should be at line 4 (after header + 3 lines), got:\n{}", output);
+    assert_eq!(
+        trunc_line, 4,
+        "truncation should be at line 4 (after header + 3 lines), got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -75,7 +86,11 @@ fn max_lines_no_truncation_when_under_limit() {
     let dir = TempDir::new().unwrap();
     let path = write_ts_file(&dir, "test.ts", LONG_FUNCTION);
     let output = run_codehud(&[&path, "processData", "--max-lines", "500"]);
-    assert!(!output.contains("[truncated:"), "should not truncate when under limit, got:\n{}", output);
+    assert!(
+        !output.contains("[truncated:"),
+        "should not truncate when under limit, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -83,7 +98,11 @@ fn max_lines_combined_with_signatures() {
     let dir = TempDir::new().unwrap();
     let path = write_ts_file(&dir, "test.ts", CLASS_CODE);
     let output = run_codehud(&[&path, "Greeter", "--signatures", "--max-lines", "2"]);
-    assert!(output.contains("[truncated:"), "expected truncation with signatures, got:\n{}", output);
+    assert!(
+        output.contains("[truncated:"),
+        "expected truncation with signatures, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -95,7 +114,11 @@ fn max_lines_multiple_symbols() {
     assert!(output.contains("helperFn"), "should contain helperFn");
     // Both should be truncated since they have more than 2 lines
     let truncation_count = output.matches("[truncated:").count();
-    assert_eq!(truncation_count, 2, "both symbols should be truncated, got:\n{}", output);
+    assert_eq!(
+        truncation_count, 2,
+        "both symbols should be truncated, got:\n{}",
+        output
+    );
 }
 
 #[test]
@@ -104,5 +127,9 @@ fn max_lines_exact_limit_no_truncation() {
     // helperFn has 7 lines (signature + 5 body + closing brace)
     let path = write_ts_file(&dir, "test.ts", LONG_FUNCTION);
     let output = run_codehud(&[&path, "helperFn", "--max-lines", "7"]);
-    assert!(!output.contains("[truncated:"), "exact limit should not truncate, got:\n{}", output);
+    assert!(
+        !output.contains("[truncated:"),
+        "exact limit should not truncate, got:\n{}",
+        output
+    );
 }

--- a/tests/max_output_lines_test.rs
+++ b/tests/max_output_lines_test.rs
@@ -13,8 +13,18 @@ fn test_max_output_lines_truncates() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.lines().collect();
     // 5 content lines + 1 footer line
-    assert_eq!(lines.len(), 6, "expected 6 lines (5 + footer), got {}:\n{}", lines.len(), stdout);
-    assert!(lines[5].starts_with("[Output truncated:"), "expected truncation footer, got: {}", lines[5]);
+    assert_eq!(
+        lines.len(),
+        6,
+        "expected 6 lines (5 + footer), got {}:\n{}",
+        lines.len(),
+        stdout
+    );
+    assert!(
+        lines[5].starts_with("[Output truncated:"),
+        "expected truncation footer, got: {}",
+        lines[5]
+    );
 }
 
 #[test]
@@ -24,31 +34,57 @@ fn test_max_output_lines_no_truncation_when_under_limit() {
         .output()
         .expect("failed to run codehud");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(!stdout.contains("[Output truncated:"), "should not truncate when under limit");
+    assert!(
+        !stdout.contains("[Output truncated:"),
+        "should not truncate when under limit"
+    );
 }
 
 #[test]
 fn test_max_output_lines_with_stats() {
     let output = codehud()
-        .args(&["tests/fixtures/sample.rs", "--stats", "--max-output-lines", "1"])
+        .args(&[
+            "tests/fixtures/sample.rs",
+            "--stats",
+            "--max-output-lines",
+            "1",
+        ])
         .output()
         .expect("failed to run codehud");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.lines().collect();
-    assert_eq!(lines.len(), 2, "expected 2 lines (1 + footer), got {}:\n{}", lines.len(), stdout);
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected 2 lines (1 + footer), got {}:\n{}",
+        lines.len(),
+        stdout
+    );
     assert!(lines[1].starts_with("[Output truncated:"));
 }
 
 #[test]
 fn test_max_output_lines_with_search() {
     let output = codehud()
-        .args(&["tests/fixtures/sample.rs", "--search", "fn", "--max-output-lines", "3"])
+        .args(&[
+            "tests/fixtures/sample.rs",
+            "--search",
+            "fn",
+            "--max-output-lines",
+            "3",
+        ])
         .output()
         .expect("failed to run codehud");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.lines().collect();
     // Should have 3 content + 1 footer = 4
-    assert_eq!(lines.len(), 4, "expected 4 lines, got {}:\n{}", lines.len(), stdout);
+    assert_eq!(
+        lines.len(),
+        4,
+        "expected 4 lines, got {}:\n{}",
+        lines.len(),
+        stdout
+    );
     assert!(lines[3].starts_with("[Output truncated:"));
 }
 
@@ -60,6 +96,12 @@ fn test_max_output_lines_with_tree() {
         .expect("failed to run codehud");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.lines().collect();
-    assert_eq!(lines.len(), 3, "expected 3 lines (2 + footer), got {}:\n{}", lines.len(), stdout);
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected 3 lines (2 + footer), got {}:\n{}",
+        lines.len(),
+        stdout
+    );
     assert!(lines[2].starts_with("[Output truncated:"));
 }

--- a/tests/outline_edge_cases_test.rs
+++ b/tests/outline_edge_cases_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 fn outline_opts() -> ProcessOptions {
     ProcessOptions {
@@ -21,6 +21,12 @@ fn outline_opts() -> ProcessOptions {
         exclude: vec![],
         outline: true,
         compact: false,
+        minimal: false,
+        expand_symbols: vec![],
+        yes: false,
+        warn_threshold: 10_000,
+        token_budget: None,
+        with_comments: false,
     }
 }
 

--- a/tests/outline_expand_test.rs
+++ b/tests/outline_expand_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 fn outline_expand_options(expand: Vec<&str>) -> ProcessOptions {
     ProcessOptions {
@@ -26,68 +26,113 @@ fn outline_expand_options(expand: Vec<&str>) -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: expand.into_iter().map(String::from).collect(),
         token_budget: None,
+        with_comments: false,
     }
 }
 
 #[test]
 fn outline_expand_shows_full_body_for_named_symbol() {
-    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting"])).unwrap();
+    let output = process_path(
+        "tests/fixtures/sample.rs",
+        outline_expand_options(vec!["greeting"]),
+    )
+    .unwrap();
     // The expanded symbol should contain its body (implementation)
-    assert!(output.contains("format!"), "expanded symbol 'greet' should show its body with format!: {}", output);
+    assert!(
+        output.contains("format!"),
+        "expanded symbol 'greet' should show its body with format!: {}",
+        output
+    );
 }
 
 #[test]
 fn outline_expand_keeps_other_symbols_as_signatures() {
-    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting"])).unwrap();
+    let output = process_path(
+        "tests/fixtures/sample.rs",
+        outline_expand_options(vec!["greeting"]),
+    )
+    .unwrap();
     // 'new' should still be in outline (signature-only) form — no body
     // The outline for 'new' in an impl block shows signature only
-    assert!(output.contains("fn new"), "outline should still contain 'new' signature: {}", output);
+    assert!(
+        output.contains("fn new"),
+        "outline should still contain 'new' signature: {}",
+        output
+    );
 }
 
 #[test]
 fn outline_expand_no_expand_is_normal_outline() {
     let normal = process_path("tests/fixtures/sample.rs", outline_expand_options(vec![])).unwrap();
-    let outline_only = process_path("tests/fixtures/sample.rs", ProcessOptions {
-        outline: true,
-        compact: false,
-        minimal: false,
-        yes: false,
-        warn_threshold: 10_000,
-        expand_symbols: vec![],
-        token_budget: None,
-        symbols: vec![],
-        pub_only: false,
-        fns_only: false,
-        types_only: false,
-        no_tests: false,
-        depth: None,
-        format: OutputFormat::Plain,
-        stats: false,
-        stats_detailed: false,
-        ext: vec![],
-        signatures: false,
-        max_lines: None,
-        list_symbols: false,
-        no_imports: false,
-        smart_depth: false,
-        symbol_depth: None,
-        exclude: vec![],
-    }).unwrap();
-    assert_eq!(normal, outline_only, "empty expand should produce same output as plain outline");
+    let outline_only = process_path(
+        "tests/fixtures/sample.rs",
+        ProcessOptions {
+            outline: true,
+            compact: false,
+            minimal: false,
+            yes: false,
+            warn_threshold: 10_000,
+            expand_symbols: vec![],
+            token_budget: None,
+            with_comments: false,
+            symbols: vec![],
+            pub_only: false,
+            fns_only: false,
+            types_only: false,
+            no_tests: false,
+            depth: None,
+            format: OutputFormat::Plain,
+            stats: false,
+            stats_detailed: false,
+            ext: vec![],
+            signatures: false,
+            max_lines: None,
+            list_symbols: false,
+            no_imports: false,
+            smart_depth: false,
+            symbol_depth: None,
+            exclude: vec![],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        normal, outline_only,
+        "empty expand should produce same output as plain outline"
+    );
 }
 
 #[test]
 fn outline_expand_top_level_function() {
-    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["public_utility"])).unwrap();
+    let output = process_path(
+        "tests/fixtures/sample.rs",
+        outline_expand_options(vec!["public_utility"]),
+    )
+    .unwrap();
     // Top-level function should be fully expanded
-    assert!(output.contains("to_uppercase"), "expanded top-level fn should show body: {}", output);
+    assert!(
+        output.contains("to_uppercase"),
+        "expanded top-level fn should show body: {}",
+        output
+    );
     // Other functions should remain as signatures
-    assert!(!output.contains("true"), "private_helper should stay as signature (no body 'true'): {}", output);
+    assert!(
+        !output.contains("true"),
+        "private_helper should stay as signature (no body 'true'): {}",
+        output
+    );
 }
 
 #[test]
 fn outline_expand_multiple_symbols() {
-    let output = process_path("tests/fixtures/sample.rs", outline_expand_options(vec!["greeting", "new"])).unwrap();
+    let output = process_path(
+        "tests/fixtures/sample.rs",
+        outline_expand_options(vec!["greeting", "new"]),
+    )
+    .unwrap();
     // Both should be expanded with their bodies
-    assert!(output.contains("format!"), "greet should be expanded: {}", output);
+    assert!(
+        output.contains("format!"),
+        "greet should be expanded: {}",
+        output
+    );
 }

--- a/tests/outline_test.rs
+++ b/tests/outline_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -23,6 +23,12 @@ fn outline_opts() -> ProcessOptions {
         exclude: vec![],
         outline: true,
         compact: false,
+        minimal: false,
+        expand_symbols: vec![],
+        yes: false,
+        warn_threshold: 10_000,
+        token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -91,9 +97,18 @@ class Config:
 fn python_outline_shows_signatures() {
     let f = write_py(PYTHON_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
-    assert!(output.contains("def helper"), "Should show helper signature");
-    assert!(output.contains("def _private_fn"), "Should show private fn signature");
-    assert!(output.contains("async def fetch_data"), "Should show async fn");
+    assert!(
+        output.contains("def helper"),
+        "Should show helper signature"
+    );
+    assert!(
+        output.contains("def _private_fn"),
+        "Should show private fn signature"
+    );
+    assert!(
+        output.contains("async def fetch_data"),
+        "Should show async fn"
+    );
     assert!(output.contains("class UserService"), "Should show class");
     assert!(output.contains("class Config"), "Should show Config class");
 }
@@ -103,9 +118,21 @@ fn python_outline_omits_bodies() {
     let f = write_py(PYTHON_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
     // Function bodies should not appear
-    assert!(!output.contains("x * 2"), "Should omit function body: {}", output);
-    assert!(!output.contains("y + 1"), "Should omit private fn body: {}", output);
-    assert!(!output.contains("await client"), "Should omit async body: {}", output);
+    assert!(
+        !output.contains("x * 2"),
+        "Should omit function body: {}",
+        output
+    );
+    assert!(
+        !output.contains("y + 1"),
+        "Should omit private fn body: {}",
+        output
+    );
+    assert!(
+        !output.contains("await client"),
+        "Should omit async body: {}",
+        output
+    );
 }
 
 #[test]
@@ -113,14 +140,20 @@ fn python_outline_shows_imports() {
     let f = write_py(PYTHON_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
     assert!(output.contains("import os"), "Should show import");
-    assert!(output.contains("from pathlib import Path"), "Should show from import");
+    assert!(
+        output.contains("from pathlib import Path"),
+        "Should show from import"
+    );
 }
 
 #[test]
 fn python_outline_shows_constants() {
     let f = write_py(PYTHON_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
-    assert!(output.contains("MY_CONST"), "Should show module-level constant");
+    assert!(
+        output.contains("MY_CONST"),
+        "Should show module-level constant"
+    );
 }
 
 #[test]
@@ -128,9 +161,18 @@ fn python_outline_class_members() {
     let f = write_py(PYTHON_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
     // Class should show member signatures
-    assert!(output.contains("def get_user"), "Should show class method signature");
-    assert!(output.contains("def __init__"), "Should show __init__ signature");
-    assert!(output.contains("def connection_string"), "Should show Config method");
+    assert!(
+        output.contains("def get_user"),
+        "Should show class method signature"
+    );
+    assert!(
+        output.contains("def __init__"),
+        "Should show __init__ signature"
+    );
+    assert!(
+        output.contains("def connection_string"),
+        "Should show Config method"
+    );
 }
 
 // ============================================================
@@ -141,18 +183,38 @@ fn python_outline_class_members() {
 fn rust_outline_shows_signatures() {
     let output = process_path("tests/fixtures/sample.rs", outline_opts()).unwrap();
     assert!(output.contains("pub struct User"), "Should show struct");
-    assert!(output.contains("pub fn new"), "Should show fn signature in impl");
-    assert!(output.contains("pub fn greeting"), "Should show method signature");
+    assert!(
+        output.contains("pub fn new"),
+        "Should show fn signature in impl"
+    );
+    assert!(
+        output.contains("pub fn greeting"),
+        "Should show method signature"
+    );
     assert!(output.contains("pub enum Role"), "Should show enum");
-    assert!(output.contains("pub trait Authenticatable"), "Should show trait");
-    assert!(output.contains("pub fn public_utility"), "Should show free fn");
+    assert!(
+        output.contains("pub trait Authenticatable"),
+        "Should show trait"
+    );
+    assert!(
+        output.contains("pub fn public_utility"),
+        "Should show free fn"
+    );
 }
 
 #[test]
 fn rust_outline_omits_bodies() {
     let output = process_path("tests/fixtures/sample.rs", outline_opts()).unwrap();
-    assert!(!output.contains("format!(\"Hello, {}!\""), "Should omit fn body: {}", output);
-    assert!(!output.contains("self.email.contains"), "Should omit validate body: {}", output);
+    assert!(
+        !output.contains("format!(\"Hello, {}!\""),
+        "Should omit fn body: {}",
+        output
+    );
+    assert!(
+        !output.contains("self.email.contains"),
+        "Should omit validate body: {}",
+        output
+    );
 }
 
 #[test]
@@ -165,13 +227,19 @@ fn rust_outline_shows_types_and_consts() {
 #[test]
 fn rust_outline_shows_imports() {
     let output = process_path("tests/fixtures/sample.rs", outline_opts()).unwrap();
-    assert!(output.contains("use std::collections::HashMap"), "Should show imports");
+    assert!(
+        output.contains("use std::collections::HashMap"),
+        "Should show imports"
+    );
 }
 
 #[test]
 fn rust_outline_shows_docstrings() {
     let output = process_path("tests/fixtures/sample.rs", outline_opts()).unwrap();
-    assert!(output.contains("/// A sample struct"), "Should show docstring");
+    assert!(
+        output.contains("/// A sample struct"),
+        "Should show docstring"
+    );
 }
 
 // ============================================================
@@ -223,7 +291,11 @@ export type UserId = string;
 fn ts_outline_shows_signatures() {
     let f = write_ts(TS_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
-    assert!(output.contains("class ApiClient"), "Should show class: {}", output);
+    assert!(
+        output.contains("class ApiClient"),
+        "Should show class: {}",
+        output
+    );
     // TS export functions may appear as export statements
     assert!(output.contains("ApiClient"), "Should contain ApiClient");
 }
@@ -232,8 +304,16 @@ fn ts_outline_shows_signatures() {
 fn ts_outline_omits_bodies() {
     let f = write_ts(TS_SAMPLE);
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
-    assert!(!output.contains("res.json()"), "Should omit fn body: {}", output);
-    assert!(!output.contains("console.error"), "Should omit method body: {}", output);
+    assert!(
+        !output.contains("res.json()"),
+        "Should omit fn body: {}",
+        output
+    );
+    assert!(
+        !output.contains("console.error"),
+        "Should omit method body: {}",
+        output
+    );
 }
 
 // ============================================================
@@ -245,10 +325,20 @@ fn outline_pub_only_rust() {
     let mut opts = outline_opts();
     opts.pub_only = true;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
-    assert!(output.contains("pub struct User"), "Should show public struct");
-    assert!(output.contains("pub fn public_utility"), "Should show public fn");
+    assert!(
+        output.contains("pub struct User"),
+        "Should show public struct"
+    );
+    assert!(
+        output.contains("pub fn public_utility"),
+        "Should show public fn"
+    );
     assert!(output.contains("pub enum Role"), "Should show public enum");
-    assert!(!output.contains("fn private_helper"), "Should omit private fn: {}", output);
+    assert!(
+        !output.contains("fn private_helper"),
+        "Should omit private fn: {}",
+        output
+    );
 }
 
 #[test]
@@ -258,7 +348,11 @@ fn outline_pub_only_python() {
     opts.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
     assert!(output.contains("def helper"), "Public fn should appear");
-    assert!(!output.contains("_private_fn"), "Private fn should be hidden: {}", output);
+    assert!(
+        !output.contains("_private_fn"),
+        "Private fn should be hidden: {}",
+        output
+    );
 }
 
 #[test]
@@ -268,8 +362,11 @@ fn outline_pub_only_ts() {
     opts.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
     // Exported symbols should appear with --pub
-    assert!(output.contains("ApiClient") || output.contains("export"),
-        "Exported class should appear: {}", output);
+    assert!(
+        output.contains("ApiClient") || output.contains("export"),
+        "Exported class should appear: {}",
+        output
+    );
 }
 
 // ============================================================
@@ -282,8 +379,16 @@ fn outline_no_tests_rust() {
     opts.no_tests = true;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
     assert!(output.contains("pub fn new"), "Should show normal fn");
-    assert!(!output.contains("mod tests"), "Should omit test module: {}", output);
-    assert!(!output.contains("test_user_creation"), "Should omit test fn: {}", output);
+    assert!(
+        !output.contains("mod tests"),
+        "Should omit test module: {}",
+        output
+    );
+    assert!(
+        !output.contains("test_user_creation"),
+        "Should omit test fn: {}",
+        output
+    );
 }
 
 #[test]
@@ -299,7 +404,11 @@ def test_helper():
     opts.no_tests = true;
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
     assert!(output.contains("def helper"), "Should show normal fn");
-    assert!(!output.contains("test_helper"), "Should omit test fn: {}", output);
+    assert!(
+        !output.contains("test_helper"),
+        "Should omit test fn: {}",
+        output
+    );
 }
 
 // ============================================================
@@ -311,9 +420,11 @@ fn outline_json_rust() {
     let mut opts = outline_opts();
     opts.format = OutputFormat::Json;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Should be valid JSON");
-    assert!(parsed.is_array() || parsed.is_object(), "JSON output should be structured");
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("Should be valid JSON");
+    assert!(
+        parsed.is_array() || parsed.is_object(),
+        "JSON output should be structured"
+    );
     let text = output.to_string();
     assert!(text.contains("User"), "JSON should contain User symbol");
 }
@@ -324,8 +435,7 @@ fn outline_json_python() {
     let mut opts = outline_opts();
     opts.format = OutputFormat::Json;
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
-    let _parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Should be valid JSON");
+    let _parsed: serde_json::Value = serde_json::from_str(&output).expect("Should be valid JSON");
     assert!(output.contains("helper"), "JSON should contain helper");
 }
 
@@ -338,8 +448,11 @@ fn outline_directory_mode() {
     let opts = outline_opts();
     let output = process_path("tests/fixtures", opts).unwrap();
     // Should process multiple files
-    assert!(output.contains("sample.rs") || output.contains("User"),
-        "Should include Rust fixture content: {}", output);
+    assert!(
+        output.contains("sample.rs") || output.contains("User"),
+        "Should include Rust fixture content: {}",
+        output
+    );
 }
 
 #[test]
@@ -348,8 +461,10 @@ fn outline_directory_with_pub() {
     opts.pub_only = true;
     let output = process_path("tests/fixtures", opts).unwrap();
     // Public symbols should appear
-    assert!(output.contains("User") || output.contains("pub"),
-        "Directory outline with --pub should show public symbols");
+    assert!(
+        output.contains("User") || output.contains("pub"),
+        "Directory outline with --pub should show public symbols"
+    );
 }
 
 // ============================================================
@@ -383,14 +498,27 @@ pub fn top_level(a: i32, b: i32) -> i32 {
     let output = process_path(f.path().to_str().unwrap(), outline_opts()).unwrap();
 
     // Verify structural properties of outline output
-    assert!(output.contains("/// Doc for Foo"), "Should preserve docstring");
+    assert!(
+        output.contains("/// Doc for Foo"),
+        "Should preserve docstring"
+    );
     assert!(output.contains("pub struct Foo"), "Should show struct");
-    assert!(output.contains("pub fn new"), "Should show public method sig");
-    assert!(output.contains("fn private_method"), "Should show private method sig");
+    assert!(
+        output.contains("pub fn new"),
+        "Should show public method sig"
+    );
+    assert!(
+        output.contains("fn private_method"),
+        "Should show private method sig"
+    );
     assert!(output.contains("pub fn top_level"), "Should show free fn");
     // Bodies should not appear
     assert!(!output.contains("a + b"), "Should omit fn body: {}", output);
-    assert!(!output.contains("self.x"), "Should omit method body: {}", output);
+    assert!(
+        !output.contains("self.x"),
+        "Should omit method body: {}",
+        output
+    );
 }
 
 #[test]
@@ -423,8 +551,16 @@ class Handler:
     assert!(output.contains("def handle"), "Should show method sig");
     assert!(output.contains("def dispatch"), "Should show method sig");
     // Bodies omitted
-    assert!(!output.contains("result.append"), "Should omit body: {}", output);
-    assert!(!output.contains("self.dispatch"), "Should omit method body: {}", output);
+    assert!(
+        !output.contains("result.append"),
+        "Should omit body: {}",
+        output
+    );
+    assert!(
+        !output.contains("self.dispatch"),
+        "Should omit method body: {}",
+        output
+    );
 }
 
 #[test]
@@ -465,7 +601,11 @@ export function createServer(config: Config): Server {
     assert!(output.contains("class Server"), "Should show class");
     assert!(output.contains("start"), "Should show method sig");
     // Bodies omitted
-    assert!(!output.contains("process.exit"), "Should omit body: {}", output);
+    assert!(
+        !output.contains("process.exit"),
+        "Should omit body: {}",
+        output
+    );
 }
 
 #[test]
@@ -493,9 +633,21 @@ impl Point {
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
 
     // Compact: params collapsed, docstrings stripped
-    assert!(output.contains("(…)"), "Compact should collapse params: {}", output);
-    assert!(!output.contains("/// A point in 2D space"), "Compact should strip docstrings: {}", output);
-    assert!(!output.contains("/// Create a new point"), "Compact should strip member docstrings: {}", output);
+    assert!(
+        output.contains("(…)"),
+        "Compact should collapse params: {}",
+        output
+    );
+    assert!(
+        !output.contains("/// A point in 2D space"),
+        "Compact should strip docstrings: {}",
+        output
+    );
+    assert!(
+        !output.contains("/// Create a new point"),
+        "Compact should strip member docstrings: {}",
+        output
+    );
 }
 
 #[test]
@@ -512,7 +664,11 @@ class Calculator:
     opts.compact = true;
     let output = process_path(f.path().to_str().unwrap(), opts).unwrap();
 
-    assert!(output.contains("(…)"), "Compact should collapse params: {}", output);
+    assert!(
+        output.contains("(…)"),
+        "Compact should collapse params: {}",
+        output
+    );
 }
 
 // ============================================================
@@ -525,10 +681,24 @@ fn outline_pub_no_tests_combined() {
     opts.pub_only = true;
     opts.no_tests = true;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
-    assert!(output.contains("pub struct User"), "Should show public struct");
-    assert!(output.contains("pub fn public_utility"), "Should show public fn");
-    assert!(!output.contains("fn private_helper"), "Should omit private: {}", output);
-    assert!(!output.contains("test_user_creation"), "Should omit tests: {}", output);
+    assert!(
+        output.contains("pub struct User"),
+        "Should show public struct"
+    );
+    assert!(
+        output.contains("pub fn public_utility"),
+        "Should show public fn"
+    );
+    assert!(
+        !output.contains("fn private_helper"),
+        "Should omit private: {}",
+        output
+    );
+    assert!(
+        !output.contains("test_user_creation"),
+        "Should omit tests: {}",
+        output
+    );
 }
 
 #[test]
@@ -537,10 +707,14 @@ fn outline_pub_json_combined() {
     opts.pub_only = true;
     opts.format = OutputFormat::Json;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
-    let _parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Should produce valid JSON");
+    let _parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("Should produce valid JSON");
     // Private symbols should not appear
-    assert!(!output.contains("private_helper"), "JSON --pub should omit private: {}", output);
+    assert!(
+        !output.contains("private_helper"),
+        "JSON --pub should omit private: {}",
+        output
+    );
 }
 
 #[test]
@@ -549,6 +723,6 @@ fn outline_compact_json() {
     opts.compact = true;
     opts.format = OutputFormat::Json;
     let output = process_path("tests/fixtures/sample.rs", opts).unwrap();
-    let _parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Compact JSON should be valid");
+    let _parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("Compact JSON should be valid");
 }

--- a/tests/passthrough_test.rs
+++ b/tests/passthrough_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, extract_lines, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, extract_lines, process_path};
 
 const TOML_FIXTURE: &str = "tests/fixtures/config.toml";
 const MD_FIXTURE: &str = "tests/fixtures/readme.md";
@@ -15,7 +15,8 @@ fn default_options() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -31,6 +32,7 @@ fn default_options() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -88,7 +90,12 @@ fn passthrough_json_output() {
     let result = process_path(TOML_FIXTURE, opts).unwrap();
     // Should be valid JSON
     let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-    assert!(parsed["files"][0]["path"].as_str().unwrap().contains("config.toml"));
+    assert!(
+        parsed["files"][0]["path"]
+            .as_str()
+            .unwrap()
+            .contains("config.toml")
+    );
 }
 
 #[test]

--- a/tests/python_test.rs
+++ b/tests/python_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,8 +28,8 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
-
 }
 
 fn write_py(content: &str) -> NamedTempFile {
@@ -86,12 +87,21 @@ fn python_interface_mode_basic() {
     let f = write_py(SAMPLE_PY);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     assert!(output.contains("import os"), "Missing import os");
-    assert!(output.contains("from pathlib import Path"), "Missing from import");
+    assert!(
+        output.contains("from pathlib import Path"),
+        "Missing from import"
+    );
     assert!(output.contains("MY_CONST"), "Missing MY_CONST");
     assert!(output.contains("BASE_URL"), "Missing BASE_URL");
     assert!(output.contains("def helper"), "Missing helper function");
-    assert!(output.contains("def _private_helper"), "Missing _private_helper");
-    assert!(output.contains("class UserService"), "Missing class UserService");
+    assert!(
+        output.contains("def _private_helper"),
+        "Missing _private_helper"
+    );
+    assert!(
+        output.contains("class UserService"),
+        "Missing class UserService"
+    );
     assert!(output.contains("class Config"), "Missing class Config");
     assert!(output.contains("{ ... }"), "Missing collapsed bodies");
 }
@@ -126,8 +136,14 @@ fn python_class_methods_in_expand() {
     let mut o = opts();
     o.symbols = vec!["UserService".to_string()];
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
-    assert!(output.contains("def get_user"), "Missing public method get_user");
-    assert!(output.contains("def _validate"), "Missing private method _validate");
+    assert!(
+        output.contains("def get_user"),
+        "Missing public method get_user"
+    );
+    assert!(
+        output.contains("def _validate"),
+        "Missing private method _validate"
+    );
     assert!(output.contains("def __init__"), "Missing __init__");
 }
 
@@ -139,7 +155,10 @@ fn python_decorator_on_method_in_expand() {
     let mut o = opts();
     o.symbols = vec!["UserService".to_string()];
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
-    assert!(output.contains("@property"), "Missing @property decorator on method");
+    assert!(
+        output.contains("@property"),
+        "Missing @property decorator on method"
+    );
 }
 
 // --- Import statements ---
@@ -149,7 +168,10 @@ fn python_imports() {
     let f = write_py(SAMPLE_PY);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     assert!(output.contains("import os"), "Missing import os");
-    assert!(output.contains("from pathlib import Path"), "Missing from import");
+    assert!(
+        output.contains("from pathlib import Path"),
+        "Missing from import"
+    );
 }
 
 // --- Module-level assignments ---
@@ -173,9 +195,18 @@ fn python_pub_filter_shows_public() {
     let mut o = opts();
     o.pub_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
-    assert!(output.contains("helper"), "Public function should appear with --pub");
-    assert!(output.contains("UserService"), "Public class should appear with --pub");
-    assert!(!output.contains("_private_helper"), "Private function should be hidden with --pub");
+    assert!(
+        output.contains("helper"),
+        "Public function should appear with --pub"
+    );
+    assert!(
+        output.contains("UserService"),
+        "Public class should appear with --pub"
+    );
+    assert!(
+        !output.contains("_private_helper"),
+        "Private function should be hidden with --pub"
+    );
 }
 
 #[test]
@@ -185,7 +216,10 @@ fn python_fns_filter() {
     o.fns_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
     assert!(output.contains("def helper"), "Missing function");
-    assert!(!output.contains("class UserService"), "Should not contain class");
+    assert!(
+        !output.contains("class UserService"),
+        "Should not contain class"
+    );
     assert!(!output.contains("import os"), "Should not contain import");
     assert!(!output.contains("MY_CONST"), "Should not contain const");
 }
@@ -198,7 +232,10 @@ fn python_types_filter() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
     assert!(output.contains("class UserService"), "Missing class");
     assert!(output.contains("Config"), "Missing Config class");
-    assert!(!output.contains("def helper"), "Should not contain standalone function");
+    assert!(
+        !output.contains("def helper"),
+        "Should not contain standalone function"
+    );
 }
 
 // --- Async functions ---
@@ -207,7 +244,10 @@ fn python_types_filter() {
 fn python_async_function() {
     let f = write_py(SAMPLE_PY);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
-    assert!(output.contains("fetch_data"), "Missing async function fetch_data");
+    assert!(
+        output.contains("fetch_data"),
+        "Missing async function fetch_data"
+    );
 }
 
 #[test]
@@ -228,7 +268,10 @@ fn python_nested_class_hidden() {
     let f = write_py(src);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     assert!(output.contains("class Outer"), "Missing Outer class");
-    assert!(!output.contains("class Inner"), "Nested class should not appear at top level");
+    assert!(
+        !output.contains("class Inner"),
+        "Nested class should not appear at top level"
+    );
 }
 
 // --- Stats ---
@@ -281,5 +324,9 @@ fn python_expand_nonexistent() {
     let result = process_path(f.path().to_str().unwrap(), o);
     assert!(result.is_err(), "Should error for nonexistent symbol");
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("not found"), "Error should mention 'not found': {}", err);
+    assert!(
+        err.contains("not found"),
+        "Error should mention 'not found': {}",
+        err
+    );
 }

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -34,13 +34,17 @@ fn write_file(dir: &TempDir, name: &str, content: &str) -> String {
 #[test]
 fn search_basic_exact_name() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "sample.rs", r#"
+    let path = write_file(
+        &dir,
+        "sample.rs",
+        r#"
 fn hello_world() {
     println!("hi");
 }
 
 fn other() {}
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", "hello_world"]);
     assert!(out.contains("hello_world"), "should find the symbol");
     assert!(!out.contains("other"), "should not include unmatched lines");
@@ -50,7 +54,10 @@ fn other() {}
 fn search_basic_in_struct() {
     let out = run_ok(&["tests/fixtures/sample.rs", "--search", "greeting"]);
     assert!(out.contains("greeting"), "should find greeting method");
-    assert!(out.contains("impl User"), "should show enclosing impl block");
+    assert!(
+        out.contains("impl User"),
+        "should show enclosing impl block"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -60,11 +67,15 @@ fn search_basic_in_struct() {
 #[test]
 fn search_regex_pattern() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", r#"
+    let path = write_file(
+        &dir,
+        "test.rs",
+        r#"
 fn get_name() {}
 fn get_age() {}
 fn set_name() {}
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", "get.*", "--regex"]);
     assert!(out.contains("get_name"), "should match get_name");
     assert!(out.contains("get_age"), "should match get_age");
@@ -74,16 +85,26 @@ fn set_name() {}
 #[test]
 fn search_regex_let_digits() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", r#"
+    let path = write_file(
+        &dir,
+        "test.rs",
+        r#"
 fn process() {
     let x = 42;
     let y = 100;
     let z = "hello";
 }
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", r"let \w+ = \d+", "--regex"]);
-    assert!(out.contains("L3:") || out.contains("let x"), "should match let x = 42");
-    assert!(out.contains("L4:") || out.contains("let y"), "should match let y = 100");
+    assert!(
+        out.contains("L3:") || out.contains("let x"),
+        "should match let x = 42"
+    );
+    assert!(
+        out.contains("L4:") || out.contains("let y"),
+        "should match let y = 100"
+    );
     assert!(!out.contains("let z"), "should not match let z = \"hello\"");
 }
 
@@ -96,26 +117,48 @@ fn search_max_results_limits_output() {
     let dir = TempDir::new().unwrap();
     // Need a directory search (max-results default applies to dirs)
     fs::create_dir(dir.path().join(".git")).unwrap();
-    write_file(&dir, "a.rs", "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n");
-    write_file(&dir, "b.rs", "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n");
+    write_file(
+        &dir,
+        "a.rs",
+        "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n",
+    );
+    write_file(
+        &dir,
+        "b.rs",
+        "fn g1() { target(); }\nfn g2() { target(); }\nfn g3() { target(); }\n",
+    );
     let dir_str = dir.path().to_string_lossy().to_string();
 
     let out = run_ok(&[&dir_str, "--search", "target", "--max-results", "1"]);
     // Should show truncation message
-    assert!(out.contains("... and"), "should indicate truncated results: {}", out);
+    assert!(
+        out.contains("... and"),
+        "should indicate truncated results: {}",
+        out
+    );
 }
 
 #[test]
 fn search_max_results_single_file() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n");
+    let path = write_file(
+        &dir,
+        "test.rs",
+        "fn f1() { target(); }\nfn f2() { target(); }\nfn f3() { target(); }\n",
+    );
     // --max-results on single file
     let out = run_ok(&[&path, "--search", "target", "--max-results", "1"]);
     // Count actual match lines (lines starting with spaces containing "L")
-    let match_lines: Vec<&str> = out.lines()
+    let match_lines: Vec<&str> = out
+        .lines()
         .filter(|l| l.contains("L") && l.contains("target"))
         .collect();
-    assert_eq!(match_lines.len(), 1, "should show exactly 1 match, got: {:?}", match_lines);
+    assert_eq!(
+        match_lines.len(),
+        1,
+        "should show exactly 1 match, got: {:?}",
+        match_lines
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -124,10 +167,22 @@ fn search_max_results_single_file() {
 
 #[test]
 fn search_no_matches_empty_output() {
-    let (stdout, stderr, success) = run_codehud(&["tests/fixtures/sample.rs", "--search", "zzz_nonexistent_zzz"]);
+    let (stdout, stderr, success) = run_codehud(&[
+        "tests/fixtures/sample.rs",
+        "--search",
+        "zzz_nonexistent_zzz",
+    ]);
     assert!(!success, "should exit non-zero when no matches found");
-    assert!(stdout.trim().is_empty(), "no matches should produce empty stdout, got: '{}'", stdout);
-    assert!(stderr.contains("No matches found"), "stderr should contain message, got: '{}'", stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "no matches should produce empty stdout, got: '{}'",
+        stdout
+    );
+    assert!(
+        stderr.contains("No matches found"),
+        "stderr should contain message, got: '{}'",
+        stderr
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -138,9 +193,8 @@ fn search_no_matches_empty_output() {
 fn search_with_json_flag() {
     // --json may not affect search output (search has its own formatter).
     // This test verifies the command doesn't error out with both flags.
-    let (stdout, _stderr, success) = run_codehud(&[
-        "tests/fixtures/sample.rs", "--search", "User", "--json",
-    ]);
+    let (stdout, _stderr, success) =
+        run_codehud(&["tests/fixtures/sample.rs", "--search", "User", "--json"]);
     assert!(success, "should not error with --search --json");
     assert!(stdout.contains("User"), "should still find User");
 }
@@ -152,13 +206,19 @@ fn search_with_json_flag() {
 #[test]
 fn search_rust_fixture() {
     let out = run_ok(&["tests/fixtures/sample.rs", "--search", "impl"]);
-    assert!(out.contains("impl User") || out.contains("impl"), "should find impl blocks");
+    assert!(
+        out.contains("impl User") || out.contains("impl"),
+        "should find impl blocks"
+    );
 }
 
 #[test]
 fn search_typescript() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "app.ts", r#"
+    let path = write_file(
+        &dir,
+        "app.ts",
+        r#"
 class Calculator {
     add(a: number, b: number): number {
         return a + b;
@@ -168,7 +228,8 @@ class Calculator {
         return a - b;
     }
 }
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", "subtract"]);
     assert!(out.contains("Calculator"), "should show enclosing class");
     assert!(out.contains("subtract"), "should find subtract method");
@@ -177,7 +238,10 @@ class Calculator {
 #[test]
 fn search_python() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "app.py", r#"
+    let path = write_file(
+        &dir,
+        "app.py",
+        r#"
 class Parser:
     def parse(self, text):
         return text.split()
@@ -187,7 +251,8 @@ class Parser:
 
 def helper():
     pass
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", "parse"]);
     assert!(out.contains("parse"), "should find parse method");
     assert!(out.contains("Parser"), "should show enclosing class");
@@ -204,12 +269,23 @@ fn search_case_insensitive() {
 
     // Case-sensitive: "hello" should NOT match "Hello" → exits non-zero (no matches)
     let (stdout, _stderr, success) = run_codehud(&[&path, "--search", "hello"]);
-    assert!(!success, "case-sensitive search with no matches should exit non-zero");
-    assert!(!stdout.contains("Hello"), "case-sensitive should not match: {}", stdout);
+    assert!(
+        !success,
+        "case-sensitive search with no matches should exit non-zero"
+    );
+    assert!(
+        !stdout.contains("Hello"),
+        "case-sensitive should not match: {}",
+        stdout
+    );
 
     // Case-insensitive
     let out = run_ok(&[&path, "--search", "hello", "-i"]);
-    assert!(out.contains("Hello"), "case-insensitive should match: {}", out);
+    assert!(
+        out.contains("Hello"),
+        "case-insensitive should match: {}",
+        out
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -222,11 +298,19 @@ fn search_directory_default_cap() {
     fs::create_dir(dir.path().join(".git")).unwrap();
     // Create 25 matches across files — default cap is 20
     for i in 0..25 {
-        write_file(&dir, &format!("f{}.rs", i), &format!("fn f{}() {{ target(); }}\n", i));
+        write_file(
+            &dir,
+            &format!("f{}.rs", i),
+            &format!("fn f{}() {{ target(); }}\n", i),
+        );
     }
     let dir_str = dir.path().to_string_lossy().to_string();
     let out = run_ok(&[&dir_str, "--search", "target"]);
-    assert!(out.contains("... and"), "directory search should cap at 20 by default: {}", out);
+    assert!(
+        out.contains("... and"),
+        "directory search should cap at 20 by default: {}",
+        out
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -236,17 +320,24 @@ fn search_directory_default_cap() {
 #[test]
 fn search_shows_symbol_hierarchy() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.ts", r#"
+    let path = write_file(
+        &dir,
+        "test.ts",
+        r#"
 class MyService {
     processRequest(req: any) {
         const result = transform(req);
         return result;
     }
 }
-"#);
+"#,
+    );
     let out = run_ok(&[&path, "--search", "transform"]);
     assert!(out.contains("MyService"), "should show enclosing class");
-    assert!(out.contains("processRequest"), "should show enclosing method");
+    assert!(
+        out.contains("processRequest"),
+        "should show enclosing method"
+    );
     assert!(out.contains("transform"), "should show the match");
 }
 
@@ -259,7 +350,10 @@ fn search_top_level_annotation() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "use std::io;\nfn main() {}\n");
     let out = run_ok(&[&path, "--search", "std::io"]);
-    assert!(out.contains("(top-level)"), "top-level matches should be annotated");
+    assert!(
+        out.contains("(top-level)"),
+        "top-level matches should be annotated"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -271,9 +365,16 @@ fn search_no_matches_exits_nonzero() {
     let dir = TempDir::new().unwrap();
     let path = write_file(&dir, "test.rs", "fn hello() {}\n");
     let (stdout, stderr, success) = run_codehud(&[&path, "--search", "zzz_nonexistent"]);
-    assert!(!success, "should exit with non-zero code when no matches found");
+    assert!(
+        !success,
+        "should exit with non-zero code when no matches found"
+    );
     assert!(stdout.is_empty(), "stdout should be empty");
-    assert!(stderr.contains("No matches found for 'zzz_nonexistent'"), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("No matches found for 'zzz_nonexistent'"),
+        "stderr: {}",
+        stderr
+    );
 }
 
 #[test]
@@ -283,9 +384,16 @@ fn search_no_matches_directory_exits_nonzero() {
     write_file(&dir, "a.rs", "fn foo() {}\n");
     let dir_path = dir.path().to_string_lossy().to_string();
     let (stdout, stderr, success) = run_codehud(&[&dir_path, "--search", "zzz_nonexistent"]);
-    assert!(!success, "should exit with non-zero code when no matches found in directory");
+    assert!(
+        !success,
+        "should exit with non-zero code when no matches found in directory"
+    );
     assert!(stdout.is_empty(), "stdout should be empty");
-    assert!(stderr.contains("No matches found for 'zzz_nonexistent'"), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("No matches found for 'zzz_nonexistent'"),
+        "stderr: {}",
+        stderr
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -295,18 +403,37 @@ fn search_no_matches_directory_exits_nonzero() {
 #[test]
 fn search_literal_mode_escapes_regex_metacharacters() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", "fn example() {\n    let pattern = \"get.*\";\n    let name = get_name();\n}\n");
+    let path = write_file(
+        &dir,
+        "test.rs",
+        "fn example() {\n    let pattern = \"get.*\";\n    let name = get_name();\n}\n",
+    );
     // Without --regex, "get.*" is literal — should only match the literal string
     let out = run_ok(&[&path, "--search", "get.*"]);
-    assert!(out.contains("get.*"), "literal mode should match literal 'get.*'");
-    let lines: Vec<&str> = out.lines().filter(|l| l.trim_start().starts_with("L")).collect();
-    assert_eq!(lines.len(), 1, "literal mode should find exactly 1 match, got: {:?}", lines);
+    assert!(
+        out.contains("get.*"),
+        "literal mode should match literal 'get.*'"
+    );
+    let lines: Vec<&str> = out
+        .lines()
+        .filter(|l| l.trim_start().starts_with("L"))
+        .collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "literal mode should find exactly 1 match, got: {:?}",
+        lines
+    );
 }
 
 #[test]
 fn search_regex_flag_enables_pattern_matching() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", "fn get_name() {}\nfn get_age() {}\nfn set_name() {}\n");
+    let path = write_file(
+        &dir,
+        "test.rs",
+        "fn get_name() {}\nfn get_age() {}\nfn set_name() {}\n",
+    );
     let out = run_ok(&[&path, "--search", "get.*", "--regex"]);
     assert!(out.contains("get_name"), "regex mode should match get_name");
     assert!(out.contains("get_age"), "regex mode should match get_age");
@@ -315,7 +442,11 @@ fn search_regex_flag_enables_pattern_matching() {
 #[test]
 fn search_short_flag_e_works() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.rs", "fn process() {\n    let x = 42;\n    let y = \"hello\";\n}\n");
+    let path = write_file(
+        &dir,
+        "test.rs",
+        "fn process() {\n    let x = 42;\n    let y = \"hello\";\n}\n",
+    );
     let out = run_ok(&[&path, "--search", r"let \w+ = \d+", "-E"]);
     assert!(out.contains("let x"), "-E should enable regex matching");
     assert!(!out.contains("let y"), "should not match string assignment");
@@ -324,10 +455,20 @@ fn search_short_flag_e_works() {
 #[test]
 fn search_env_var_pattern_with_regex() {
     let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.ts", "function config() {\n    const host = process.env.HOST;\n    const port = process.env.PORT;\n    const name = \"codeview\";\n}\n");
+    let path = write_file(
+        &dir,
+        "test.ts",
+        "function config() {\n    const host = process.env.HOST;\n    const port = process.env.PORT;\n    const name = \"codeview\";\n}\n",
+    );
     let out = run_ok(&[&path, "--search", r"process\.env\.\w+", "-E"]);
-    assert!(out.contains("process.env.HOST"), "should match HOST env var");
-    assert!(out.contains("process.env.PORT"), "should match PORT env var");
+    assert!(
+        out.contains("process.env.HOST"),
+        "should match HOST env var"
+    );
+    assert!(
+        out.contains("process.env.PORT"),
+        "should match PORT env var"
+    );
     assert!(!out.contains("codeview"), "should not match plain string");
 }
 
@@ -344,7 +485,11 @@ fn search_limit_flag_caps_results() {
     let dir_str = dir.path().to_string_lossy().to_string();
     let out = run_ok(&[&dir_str, "--search", "target", "--limit", "5"]);
     // Should show the overflow message
-    assert!(out.contains("... and 15 more matches"), "should cap at 5 results: {}", out);
+    assert!(
+        out.contains("... and 15 more matches"),
+        "should cap at 5 results: {}",
+        out
+    );
 }
 
 #[test]
@@ -356,5 +501,9 @@ fn search_limit_flag_single_file() {
     }
     let path = write_file(&dir, "test.rs", &content);
     let out = run_ok(&[&path, "--search", "target", "--limit", "3"]);
-    assert!(out.contains("... and 7 more matches"), "should cap at 3 results: {}", out);
+    assert!(
+        out.contains("... and 7 more matches"),
+        "should cap at 3 results: {}",
+        out
+    );
 }

--- a/tests/sfc_test.rs
+++ b/tests/sfc_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,6 +28,7 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
 }
 
@@ -69,8 +71,14 @@ fn vue_script_setup_interface_mode() {
     let f = write_file(".vue", VUE_SCRIPT_SETUP);
     let out = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     // Should extract the interface, const, and function
-    assert!(out.contains("interface Props"), "Should find Props interface: {out}");
-    assert!(out.contains("increment"), "Should find increment function: {out}");
+    assert!(
+        out.contains("interface Props"),
+        "Should find Props interface: {out}"
+    );
+    assert!(
+        out.contains("increment"),
+        "Should find increment function: {out}"
+    );
 }
 
 #[test]
@@ -95,7 +103,11 @@ fn vue_line_numbers_offset() {
     let items = files[0]["items"].as_array().unwrap();
     // Props interface starts at line 4 in the .vue (line 3 in script + 1 offset)
     let props_item = items.iter().find(|i| i["name"] == "Props").unwrap();
-    assert!(props_item["line_start"].as_u64().unwrap() >= 4, "Props should be at line >= 4: {}", props_item);
+    assert!(
+        props_item["line_start"].as_u64().unwrap() >= 4,
+        "Props should be at line >= 4: {}",
+        props_item
+    );
 }
 
 const VUE_OPTIONS_API: &str = r#"<script lang="ts">
@@ -121,7 +133,10 @@ export default defineComponent({
 fn vue_options_api() {
     let f = write_file(".vue", VUE_OPTIONS_API);
     let out = process_path(f.path().to_str().unwrap(), opts()).unwrap();
-    assert!(out.contains("defineComponent") || out.contains("import"), "Should parse options API: {out}");
+    assert!(
+        out.contains("defineComponent") || out.contains("import"),
+        "Should parse options API: {out}"
+    );
 }
 
 const VUE_TWO_SCRIPTS: &str = r#"<script lang="ts">
@@ -145,7 +160,10 @@ const count = ref(0)
 fn vue_two_script_blocks() {
     let f = write_file(".vue", VUE_TWO_SCRIPTS);
     let out = process_path(f.path().to_str().unwrap(), opts()).unwrap();
-    assert!(out.contains("SharedType"), "Should find SharedType from first script: {out}");
+    assert!(
+        out.contains("SharedType"),
+        "Should find SharedType from first script: {out}"
+    );
 }
 
 // --- Svelte tests ---
@@ -174,7 +192,10 @@ fn svelte_script_extraction() {
     let f = write_file(".svelte", SVELTE_COMPONENT);
     let out = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     assert!(out.contains("Item"), "Should find Item interface: {out}");
-    assert!(out.contains("handleClick"), "Should find handleClick: {out}");
+    assert!(
+        out.contains("handleClick"),
+        "Should find handleClick: {out}"
+    );
 }
 
 // --- Astro tests ---
@@ -227,7 +248,10 @@ fn vue_template_only_passthrough() {
     let f = write_file(".vue", source);
     let out = process_path(f.path().to_str().unwrap(), opts()).unwrap();
     // Should still produce output (passthrough of the whole file)
-    assert!(out.contains("template") || out.contains("Hello"), "Should passthrough: {out}");
+    assert!(
+        out.contains("template") || out.contains("Hello"),
+        "Should passthrough: {out}"
+    );
 }
 
 // --- List symbols ---
@@ -239,7 +263,10 @@ fn vue_list_symbols() {
     o.list_symbols = true;
     let out = process_path(f.path().to_str().unwrap(), o).unwrap();
     assert!(out.contains("Props"), "Should list Props symbol: {out}");
-    assert!(out.contains("increment"), "Should list increment symbol: {out}");
+    assert!(
+        out.contains("increment"),
+        "Should list increment symbol: {out}"
+    );
 }
 
 // --- Directory scanning tests for SFC files ---
@@ -247,10 +274,14 @@ fn vue_list_symbols() {
 #[test]
 fn sfc_directory_stats_finds_vue_files() {
     let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("App.vue"), r#"<script setup lang="ts">
+    std::fs::write(
+        dir.path().join("App.vue"),
+        r#"<script setup lang="ts">
 const msg = 'hello'
 </script>
-<template><div>{{ msg }}</div></template>"#).unwrap();
+<template><div>{{ msg }}</div></template>"#,
+    )
+    .unwrap();
     std::fs::write(dir.path().join("main.ts"), "import App from './App.vue'").unwrap();
 
     let mut o = opts();
@@ -264,9 +295,21 @@ const msg = 'hello'
 #[test]
 fn sfc_directory_stats_finds_all_sfc_types() {
     let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("App.vue"), "<script>export default {}</script>").unwrap();
-    std::fs::write(dir.path().join("Counter.svelte"), "<script>let count = 0</script>").unwrap();
-    std::fs::write(dir.path().join("Index.astro"), "---\nconst x = 1\n---\n<div/>").unwrap();
+    std::fs::write(
+        dir.path().join("App.vue"),
+        "<script>export default {}</script>",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Counter.svelte"),
+        "<script>let count = 0</script>",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Index.astro"),
+        "---\nconst x = 1\n---\n<div/>",
+    )
+    .unwrap();
 
     let mut o = opts();
     o.stats = true;
@@ -280,12 +323,16 @@ fn sfc_directory_stats_finds_all_sfc_types() {
 #[test]
 fn sfc_directory_search_finds_vue_content() {
     let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("App.vue"), r#"<script setup lang="ts">
+    std::fs::write(
+        dir.path().join("App.vue"),
+        r#"<script setup lang="ts">
 import { ref } from 'vue'
 const count = ref(0)
 function increment() { count.value++ }
 </script>
-<template><button @click="increment">{{ count }}</button></template>"#).unwrap();
+<template><button @click="increment">{{ count }}</button></template>"#,
+    )
+    .unwrap();
 
     let out = codehud::search::search_path(
         dir.path().to_str().unwrap(),
@@ -303,19 +350,27 @@ function increment() { count.value++ }
             summary: false,
             files_first: false,
         },
-    ).unwrap();
-    assert!(out.contains("increment"), "Should find increment in Vue file: {out}");
+    )
+    .unwrap();
+    assert!(
+        out.contains("increment"),
+        "Should find increment in Vue file: {out}"
+    );
     assert!(out.contains("App.vue"), "Should show Vue filename: {out}");
 }
 
 #[test]
 fn sfc_directory_search_finds_svelte_content() {
     let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("Counter.svelte"), r#"<script>
+    std::fs::write(
+        dir.path().join("Counter.svelte"),
+        r#"<script>
 let count = 0
 function increment() { count++ }
 </script>
-<button on:click={increment}>{count}</button>"#).unwrap();
+<button on:click={increment}>{count}</button>"#,
+    )
+    .unwrap();
 
     let out = codehud::search::search_path(
         dir.path().to_str().unwrap(),
@@ -333,7 +388,14 @@ function increment() { count++ }
             summary: false,
             files_first: false,
         },
-    ).unwrap();
-    assert!(out.contains("increment"), "Should find increment in Svelte: {out}");
-    assert!(out.contains("Counter.svelte"), "Should show Svelte filename: {out}");
+    )
+    .unwrap();
+    assert!(
+        out.contains("increment"),
+        "Should find increment in Svelte: {out}"
+    );
+    assert!(
+        out.contains("Counter.svelte"),
+        "Should show Svelte filename: {out}"
+    );
 }

--- a/tests/skill_test.rs
+++ b/tests/skill_test.rs
@@ -39,9 +39,18 @@ fn install_uninstall_stubs_return_not_implemented() {
             .args(["install-skill", platform])
             .output()
             .expect("failed to run");
-        assert!(!output.status.success(), "expected failure for {}", platform);
+        assert!(
+            !output.status.success(),
+            "expected failure for {}",
+            platform
+        );
         let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stderr.contains("not yet implemented"), "platform {} stderr: {}", platform, stderr);
+        assert!(
+            stderr.contains("not yet implemented"),
+            "platform {} stderr: {}",
+            platform,
+            stderr
+        );
     }
 }
 
@@ -52,9 +61,15 @@ fn openclaw_install_and_uninstall() {
         .args(["install-skill", "openclaw"])
         .output()
         .expect("failed to run");
-    assert!(output.status.success(), "install failed: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
-    let skill_path = dirs::home_dir().unwrap().join(".openclaw/workspace/skills/codehud/SKILL.md");
+    let skill_path = dirs::home_dir()
+        .unwrap()
+        .join(".openclaw/workspace/skills/codehud/SKILL.md");
     assert!(skill_path.exists(), "SKILL.md should exist after install");
 
     let content = std::fs::read_to_string(&skill_path).unwrap();
@@ -75,8 +90,15 @@ fn openclaw_install_and_uninstall() {
         .args(["uninstall-skill", "openclaw"])
         .output()
         .expect("failed to run");
-    assert!(output3.status.success(), "uninstall failed: {}", String::from_utf8_lossy(&output3.stderr));
-    assert!(!skill_path.exists(), "SKILL.md should be removed after uninstall");
+    assert!(
+        output3.status.success(),
+        "uninstall failed: {}",
+        String::from_utf8_lossy(&output3.stderr)
+    );
+    assert!(
+        !skill_path.exists(),
+        "SKILL.md should be removed after uninstall"
+    );
 }
 
 #[test]
@@ -87,7 +109,11 @@ fn cursor_install_and_uninstall() {
         .current_dir(tmp.path())
         .output()
         .expect("failed to run");
-    assert!(output.status.success(), "install failed: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let mdc_path = tmp.path().join(".cursor/rules/codehud.mdc");
     assert!(mdc_path.exists(), "codehud.mdc should exist after install");
@@ -112,8 +138,15 @@ fn cursor_install_and_uninstall() {
         .current_dir(tmp.path())
         .output()
         .expect("failed to run");
-    assert!(output3.status.success(), "uninstall failed: {}", String::from_utf8_lossy(&output3.stderr));
-    assert!(!mdc_path.exists(), "codehud.mdc should be removed after uninstall");
+    assert!(
+        output3.status.success(),
+        "uninstall failed: {}",
+        String::from_utf8_lossy(&output3.stderr)
+    );
+    assert!(
+        !mdc_path.exists(),
+        "codehud.mdc should be removed after uninstall"
+    );
 }
 
 #[test]
@@ -135,7 +168,11 @@ fn codex_install_creates_agents_md() {
         .current_dir(dir.path())
         .output()
         .expect("failed to run");
-    assert!(output.status.success(), "install failed: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let agents = dir.path().join("AGENTS.md");
     assert!(agents.exists(), "AGENTS.md should be created");
@@ -209,7 +246,11 @@ fn codex_uninstall_removes_block() {
 #[test]
 fn codex_uninstall_preserves_other_content() {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("AGENTS.md"), "# My Project\n\nSome instructions.\n").unwrap();
+    std::fs::write(
+        dir.path().join("AGENTS.md"),
+        "# My Project\n\nSome instructions.\n",
+    )
+    .unwrap();
 
     codehud()
         .args(["install-skill", "codex"])

--- a/tests/symbol_not_found_test.rs
+++ b/tests/symbol_not_found_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 
 const FIXTURE_PATH: &str = "tests/fixtures/sample.rs";
 
@@ -27,6 +27,7 @@ fn default_options() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
         stats_detailed: true,
     }
 }
@@ -40,8 +41,16 @@ fn test_symbol_not_found_returns_error() {
     let result = process_path(FIXTURE_PATH, options);
     assert!(result.is_err(), "Expected error for non-existent symbol");
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("nonExistentSymbol"), "Error should mention the symbol name: {}", err);
-    assert!(err.contains("not found"), "Error should say 'not found': {}", err);
+    assert!(
+        err.contains("nonExistentSymbol"),
+        "Error should mention the symbol name: {}",
+        err
+    );
+    assert!(
+        err.contains("not found"),
+        "Error should say 'not found': {}",
+        err
+    );
 }
 
 #[test]
@@ -62,7 +71,11 @@ fn test_existing_symbol_still_works() {
         ..default_options()
     };
     let result = process_path(FIXTURE_PATH, options);
-    assert!(result.is_ok(), "Existing symbol should work: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Existing symbol should work: {:?}",
+        result.err()
+    );
     let output = result.unwrap();
     assert!(output.contains("User"), "Output should contain the symbol");
 }

--- a/tests/typescript_test.rs
+++ b/tests/typescript_test.rs
@@ -1,4 +1,4 @@
-use codehud::{process_path, ProcessOptions, OutputFormat};
+use codehud::{OutputFormat, ProcessOptions, process_path};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -11,7 +11,8 @@ fn opts() -> ProcessOptions {
         no_tests: false,
         depth: None,
         format: OutputFormat::Plain,
-        stats: false, stats_detailed: true,
+        stats: false,
+        stats_detailed: true,
         ext: vec![],
         signatures: false,
         max_lines: None,
@@ -27,8 +28,8 @@ fn opts() -> ProcessOptions {
         warn_threshold: 10_000,
         expand_symbols: vec![],
         token_budget: None,
+        with_comments: false,
     }
-
 }
 
 fn write_ts(content: &str) -> NamedTempFile {
@@ -108,7 +109,10 @@ fn ts_interface_mode_basic() {
     assert!(output.contains("const MAX_USERS"), "Missing const");
     assert!(output.contains("class UserService"), "Missing class");
     assert!(output.contains("import"), "Missing import");
-    assert!(output.contains("function helperFunction"), "Missing helperFunction");
+    assert!(
+        output.contains("function helperFunction"),
+        "Missing helperFunction"
+    );
     assert!(output.contains("function publicApi"), "Missing publicApi");
     // Bodies should be collapsed
     assert!(output.contains("{ ... }"), "Missing collapsed bodies");
@@ -124,7 +128,10 @@ fn ts_expand_symbol() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("function publicApi"), "Missing publicApi");
-    assert!(output.contains("trim().toLowerCase()"), "Missing function body");
+    assert!(
+        output.contains("trim().toLowerCase()"),
+        "Missing function body"
+    );
 }
 
 #[test]
@@ -135,7 +142,10 @@ fn ts_expand_class() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("class UserService"), "Missing class");
-    assert!(output.contains("new Map()") || output.contains("this.db"), "Missing class body");
+    assert!(
+        output.contains("new Map()") || output.contains("this.db"),
+        "Missing class body"
+    );
 }
 
 // --- --pub filter ---
@@ -148,10 +158,19 @@ fn ts_pub_filter() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     // Exported items should appear
-    assert!(output.contains("interface User"), "Missing exported interface");
-    assert!(output.contains("function publicApi"), "Missing exported function");
+    assert!(
+        output.contains("interface User"),
+        "Missing exported interface"
+    );
+    assert!(
+        output.contains("function publicApi"),
+        "Missing exported function"
+    );
     // Non-exported items should not
-    assert!(!output.contains("helperFunction"), "Should not contain non-exported helperFunction");
+    assert!(
+        !output.contains("helperFunction"),
+        "Should not contain non-exported helperFunction"
+    );
 }
 
 // --- --fns filter ---
@@ -164,10 +183,15 @@ fn ts_fns_filter() {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     // Functions and methods should appear
-    assert!(output.contains("function helperFunction") || output.contains("function publicApi"),
-            "Missing functions");
+    assert!(
+        output.contains("function helperFunction") || output.contains("function publicApi"),
+        "Missing functions"
+    );
     // Types should not
-    assert!(!output.contains("interface User"), "Should not contain interface");
+    assert!(
+        !output.contains("interface User"),
+        "Should not contain interface"
+    );
     assert!(!output.contains("enum Role"), "Should not contain enum");
 }
 
@@ -185,7 +209,10 @@ fn ts_types_filter() {
     assert!(output.contains("type UserId"), "Missing type alias");
     assert!(output.contains("class UserService"), "Missing class");
     // Standalone functions should not appear
-    assert!(!output.contains("function helperFunction"), "Should not contain standalone fn");
+    assert!(
+        !output.contains("function helperFunction"),
+        "Should not contain standalone fn"
+    );
 }
 
 // --- --no-tests (no-op for TS, shouldn't break) ---
@@ -197,8 +224,14 @@ fn ts_no_tests_noop() {
     o.no_tests = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("class UserService"), "Missing class with --no-tests");
-    assert!(output.contains("interface User"), "Missing interface with --no-tests");
+    assert!(
+        output.contains("class UserService"),
+        "Missing class with --no-tests"
+    );
+    assert!(
+        output.contains("interface User"),
+        "Missing interface with --no-tests"
+    );
 }
 
 // --- Abstract class ---
@@ -218,10 +251,19 @@ export abstract class Shape {
     let f = write_ts(src);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("abstract class Shape"), "Missing abstract class");
+    assert!(
+        output.contains("abstract class Shape"),
+        "Missing abstract class"
+    );
     assert!(output.contains("area()"), "Missing abstract method area");
-    assert!(output.contains("perimeter()"), "Missing abstract method perimeter");
-    assert!(output.contains("describe()"), "Missing concrete method describe");
+    assert!(
+        output.contains("perimeter()"),
+        "Missing abstract method perimeter"
+    );
+    assert!(
+        output.contains("describe()"),
+        "Missing concrete method describe"
+    );
 }
 
 // --- TSX detection ---
@@ -249,8 +291,14 @@ export class Counter extends React.Component<Props> {
     let f = write_tsx(src);
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
-    assert!(output.contains("interface Props"), "Missing interface in TSX");
-    assert!(output.contains("function Greeting"), "Missing function in TSX");
+    assert!(
+        output.contains("interface Props"),
+        "Missing interface in TSX"
+    );
+    assert!(
+        output.contains("function Greeting"),
+        "Missing function in TSX"
+    );
     assert!(output.contains("class Counter"), "Missing class in TSX");
 }
 
@@ -276,9 +324,12 @@ fn ts_stats_json() {
     o.format = OutputFormat::Json;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    let parsed: serde_json::Value = serde_json::from_str(&output)
-        .expect("Stats JSON should be valid");
-    assert!(parsed.is_object() || parsed.is_array(), "Should be structured JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("Stats JSON should be valid");
+    assert!(
+        parsed.is_object() || parsed.is_array(),
+        "Should be structured JSON"
+    );
 }
 
 // --- Decorator support (issue #29) ---
@@ -343,7 +394,10 @@ export abstract class BaseController {
     let output = process_path(f.path().to_str().unwrap(), opts()).unwrap();
 
     assert!(output.contains("@Controller()"), "Missing decorator");
-    assert!(output.contains("abstract class BaseController"), "Missing abstract class");
+    assert!(
+        output.contains("abstract class BaseController"),
+        "Missing abstract class"
+    );
 }
 
 #[test]
@@ -361,7 +415,10 @@ export class MyService {
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
     assert!(output.contains("@Service()"), "Missing decorator in expand");
-    assert!(output.contains("class MyService"), "Missing class in expand");
+    assert!(
+        output.contains("class MyService"),
+        "Missing class in expand"
+    );
     assert!(output.contains("return 'hello'"), "Missing body in expand");
 }
 
@@ -393,91 +450,149 @@ fn ts_pub_fns_combined() {
     o.fns_only = true;
     let output = process_path(f.path().to_str().unwrap(), o).unwrap();
 
-    assert!(output.contains("function publicApi"), "Missing exported function");
-    assert!(!output.contains("helperFunction"), "Should not contain non-exported fn");
-    assert!(!output.contains("interface User"), "Should not contain types");
+    assert!(
+        output.contains("function publicApi"),
+        "Missing exported function"
+    );
+    assert!(
+        !output.contains("helperFunction"),
+        "Should not contain non-exported fn"
+    );
+    assert!(
+        !output.contains("interface User"),
+        "Should not contain types"
+    );
 }
 
 // === Per-language visibility filtering (issue #82) ===
 
 #[test]
 fn ts_pub_filter_hides_private_methods() {
-    let f = write_ts(r#"
+    let f = write_ts(
+        r#"
 export class Foo {
     public greet(): void {}
     protected helper(): void {}
     private internal(): void {}
     open(): void {}
 }
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        fns_only: true,
-        ..opts()
-    }).unwrap();
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            fns_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
     assert!(out.contains("greet"), "public method should be visible");
-    assert!(out.contains("open"), "default (no modifier) method should be visible");
+    assert!(
+        out.contains("open"),
+        "default (no modifier) method should be visible"
+    );
     assert!(!out.contains("helper"), "protected method should be hidden");
     assert!(!out.contains("internal"), "private method should be hidden");
 }
 
 #[test]
 fn ts_pub_filter_hides_hash_private() {
-    let f = write_ts(r#"
+    let f = write_ts(
+        r#"
 export class Foo {
     public greet(): void {}
     #secret(): number { return 42; }
 }
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        fns_only: true,
-        ..opts()
-    }).unwrap();
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            fns_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
     assert!(out.contains("greet"), "public method should be visible");
     assert!(!out.contains("secret"), "#private method should be hidden");
 }
 
 #[test]
 fn ts_pub_filter_non_exported_top_level_hidden() {
-    let f = write_ts(r#"
+    let f = write_ts(
+        r#"
 export function publicFn(): void {}
 function privateFn(): void {}
 export class PublicClass {}
 class PrivateClass {}
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        ..opts()
-    }).unwrap();
-    assert!(out.contains("publicFn"), "exported function should be visible");
-    assert!(out.contains("PublicClass"), "exported class should be visible");
-    assert!(!out.contains("privateFn"), "non-exported function should be hidden");
-    assert!(!out.contains("PrivateClass"), "non-exported class should be hidden");
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
+    assert!(
+        out.contains("publicFn"),
+        "exported function should be visible"
+    );
+    assert!(
+        out.contains("PublicClass"),
+        "exported class should be visible"
+    );
+    assert!(
+        !out.contains("privateFn"),
+        "non-exported function should be hidden"
+    );
+    assert!(
+        !out.contains("PrivateClass"),
+        "non-exported class should be hidden"
+    );
 }
 
 #[test]
 fn ts_visibility_protected_in_json() {
-    let f = write_ts(r#"
+    let f = write_ts(
+        r#"
 export class Foo {
     public a(): void {}
     protected b(): void {}
     private c(): void {}
 }
-"#);
-    let json_out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        format: OutputFormat::Json,
-        fns_only: true,
-        ..opts()
-    }).unwrap();
-    assert!(json_out.contains("\"protected\""), "JSON should show protected visibility");
-    assert!(json_out.contains("\"private\""), "JSON should show private visibility");
-    assert!(json_out.contains("\"public\""), "JSON should show public visibility");
+"#,
+    );
+    let json_out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            format: OutputFormat::Json,
+            fns_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
+    assert!(
+        json_out.contains("\"protected\""),
+        "JSON should show protected visibility"
+    );
+    assert!(
+        json_out.contains("\"private\""),
+        "JSON should show private visibility"
+    );
+    assert!(
+        json_out.contains("\"public\""),
+        "JSON should show public visibility"
+    );
 }
 
 #[test]
 fn ts_pub_filter_hides_private_members_in_class_body() {
-    let f = write_ts(r#"
+    let f = write_ts(
+        r#"
 export class MyClass {
     private secret: string;
     public name: string;
@@ -490,15 +605,29 @@ export class MyClass {
         return 2;
     }
 }
-"#);
-    let out = process_path(f.path().to_str().unwrap(), ProcessOptions {
-        pub_only: true,
-        ..opts()
-    }).unwrap();
+"#,
+    );
+    let out = process_path(
+        f.path().to_str().unwrap(),
+        ProcessOptions {
+            pub_only: true,
+            ..opts()
+        },
+    )
+    .unwrap();
     // Class content should not contain private members
-    assert!(!out.contains("secret"), "private field 'secret' should be hidden from class body with --pub");
-    assert!(!out.contains("internalMethod"), "private method should be hidden from class body with --pub");
+    assert!(
+        !out.contains("secret"),
+        "private field 'secret' should be hidden from class body with --pub"
+    );
+    assert!(
+        !out.contains("internalMethod"),
+        "private method should be hidden from class body with --pub"
+    );
     assert!(out.contains("name"), "public field should remain visible");
-    assert!(out.contains("publicMethod"), "public method should remain visible");
+    assert!(
+        out.contains("publicMethod"),
+        "public method should remain visible"
+    );
     assert!(out.contains("MyClass"), "class name should be visible");
 }


### PR DESCRIPTION
## Summary

Adds language-aware doc comment extraction via a new `get_doc_comment()` trait method on `LanguageHandler`, with per-language overrides for Go, Python, TypeScript, and JavaScript.

## Problem

The existing `get_docstring()` in `outline.rs` was Rust-biased:
- **Go**: Silently dropped ALL doc comments (filtered out plain `//`, required `///`)
- **Python**: Missed docstrings entirely (looked at preceding siblings instead of body)
- **TS/JS**: Partially worked for JSDoc but didn't handle export wrapping

## Solution

### New trait method
```rust
fn get_doc_comment(&self, source: &str, node: Node) -> Option<String>
```

### Per-language implementations
| Language | Strategy |
|----------|----------|
| Rust/C#/Kotlin/Java | Default: walk back through `///` and `/**` comment siblings |
| Go | Accept ALL `//` comments preceding a declaration (godoc convention) |
| Python | Extract docstring from first `expression_statement > string` in body |
| TypeScript/JavaScript | Handle JSDoc `/**` blocks with export-statement wrapping |

### CLI flag
`--with-comments` enables doc comment extraction in two modes:
- **Symbol expand**: `codehud file.go Add --with-comments` — prepends doc comment to output
- **List symbols JSON**: `codehud file.py --list-symbols --json --with-comments` — adds `doc_comment` field

### Data model
Added `doc_comment: Option<String>` to `Item` struct, serialized with `skip_serializing_if = "Option::is_none"`.

## Testing
- All existing tests pass
- Manually verified on Rust, Go, Python, and TypeScript files
- Doc comments correctly extracted per language convention

## Analysis
Based on detailed analysis in `/tmp/codehud-comments-analysis.md` (670 lines).